### PR TITLE
Add py.typed to declare we have type annotations

### DIFF
--- a/reddit_experiments/py.typed
+++ b/reddit_experiments/py.typed
@@ -1,0 +1,1 @@
+# https://www.python.org/dev/peps/pep-0561/#packaging-type-information


### PR DESCRIPTION
Even though all this code has proper annotations, they're not getting
used because we don't have py.typed in place. This should allow our
clients to use our types properly.