### PR TITLE
Decider

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -8,7 +8,5 @@ __pycache__/
 /.dockerignore
 /.git
 /Dockerfile
-/tests/range_variant_tests/data/original_zk_config.json
-/tests/range_variant_tests/data/range_variant_zk_config.json
-/tests/range_variant_tests/data/output.json
+/tests/range_variant_tests/data/*
 venv*

--- a/.github/workflows/python-package.yaml
+++ b/.github/workflows/python-package.yaml
@@ -11,6 +11,7 @@ jobs:
 
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         python-version: ['3.7', '3.8', '3.9', '3.10']
 

--- a/.github/workflows/python-package.yaml
+++ b/.github/workflows/python-package.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9, 3.10]
 
     steps:
     - uses: actions/checkout@v2
@@ -35,7 +35,7 @@ jobs:
 
     - name: Lint
       run: |
-        make lint
+        make lint PYTHON_VERSION=${{ matrix.python-version }}
 
     - name: Test
       run: |

--- a/.github/workflows/python-package.yaml
+++ b/.github/workflows/python-package.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9, 3.10]
+        python-version: ['3.7', '3.8', '3.9', '3.10']
 
     steps:
     - uses: actions/checkout@v2

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8
+FROM python:3.9
 
 WORKDIR /src
 COPY requirements*.txt .

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ lint:
 	$(REORDER_PYTHON_IMPORTS) --diff-only $(PYTHON_SOURCE)
 	black --diff --check $(PYTHON_SOURCE)
 	flake8 $(SOURCE_ROOT)
-	mypy $(SOURCE_ROOT) --python-version $(python_version)
+	mypy $(SOURCE_ROOT) --python-version $(PYTHON_VERSION)
 
 .PHONY: test
 test:

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ lint:
 	$(REORDER_PYTHON_IMPORTS) --diff-only $(PYTHON_SOURCE)
 	black --diff --check $(PYTHON_SOURCE)
 	flake8 $(SOURCE_ROOT)
-	mypy $(SOURCE_ROOT)
+	mypy $(SOURCE_ROOT) --python-version $(python_version)
 
 .PHONY: test
 test:

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 SOURCE_ROOT := reddit_experiments/
-PYTHON_SOURCE = $(shell find $(SOURCE_ROOT) tests/ setup.py -name '*.py')
+PYTHON_SOURCE = $($(shell) find $(SOURCE_ROOT) tests/ setup.py -name '*.py')
 REORDER_PYTHON_IMPORTS := reorder-python-imports --py3-plus --separate-from-import --separate-relative
-
+PYTHON_VERSION ?= 3.9
 
 .PHONY: fmt
 fmt:

--- a/reddit_decider/__init__.py
+++ b/reddit_decider/__init__.py
@@ -1,0 +1,453 @@
+import logging
+
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, Optional
+
+from baseplate import Span
+from baseplate.clients import ContextFactory
+from baseplate.frameworks.pyramid import BaseplateRequest
+from baseplate.lib import config
+from baseplate.lib.events import DebugLogger
+from baseplate.lib.events import EventLogger
+from baseplate.lib.file_watcher import FileWatcher
+from baseplate.lib.file_watcher import WatchedFileNotAvailableError
+
+import rust_decider
+
+
+logger = logging.getLogger(__name__)
+
+EMPLOYEE_ROLES = ("employee", "contractor")
+EVENT_TYPE = "expose"
+
+
+@dataclass
+class ExperimentConfig:
+    id: int
+    version: int
+    name: str
+    variant: str
+    bucket_val: str
+    start_ts: int
+    stop_ts: int
+    owner: str
+
+
+class DeciderContext:
+    """DeciderContext() is used to contain all fields necessary for
+    bucketing, targeting, and overrides.
+    DeciderContext() is populated in `make_object_for_context()`.
+    """
+
+    def __init__(
+        self,
+        user_id: str,
+        country_code: Optional[str] = None,
+        user_is_employee: Optional[bool] = None,
+        logged_in: Optional[bool] = None,
+        device_id: Optional[str] = None,
+        request_url: Optional[str] = None,
+        authentication_token: Optional[str] = None,
+        app_name: Optional[str] = None,
+        build_number: Optional[str] = None,
+        loid: Optional[str] = None,
+        cookie_created_timestamp: Optional[float] = None,
+        event_fields: Dict[str, Any] = None
+    ):
+        self._user_id = user_id
+        self._country_code = country_code
+        self._user_is_employee = user_is_employee
+        self._logged_in = logged_in
+        self._device_id = device_id
+        self._request_url = request_url
+        self._authentication_token = authentication_token
+        self._app_name = app_name
+        self._build_number = build_number
+        self._loid = loid
+        self._cookie_created_timestamp = cookie_created_timestamp
+        self._event_fields = event_fields
+
+    def get_event_fields(self):
+        return self._event_fields or {}
+
+    def to_dict(self):
+        return {
+            "user_id": self._user_id,
+            "country_code": self._country_code,
+            "user_is_employee": self._user_is_employee,
+            "logged_in": self._logged_in,
+            "device_id": self._device_id,
+            "request_url": self._request_url,
+            "authentication_token": self._authentication_token,
+            "app_name": self._app_name,
+            "build_number": self._build_number,
+            "loid": self._loid,
+            "cookie_created_timestamp": self._cookie_created_timestamp,
+        }
+
+
+def init_decider_parser(file):
+    return rust_decider.init("darkmode overrides targeting fractional_availability value", file.name)
+
+
+class DeciderContextFactory(ContextFactory):
+    """Decider client context factory.
+
+    This factory will attach a new
+    :py:class:`reddit_decider.Decider` to an attribute on the
+    :py:class:`~baseplate.RequestContext`.
+
+    :param path: Path to the experiment configuration file.
+    :param event_logger: The logger to use to log experiment eligibility
+        events. If not provided, a :py:class:`~baseplate.lib.events.DebugLogger`
+        will be created and used.
+    :param timeout: How long, in seconds, to block instantiation waiting
+        for the watched experiments file to become available (defaults to not
+        blocking).
+    :param backoff: retry backoff time for experiments file watcher. Defaults to
+        None, which is mapped to DEFAULT_FILEWATCHER_BACKOFF.
+    :param request_field_extractor: an optional function used to populate
+        "app_name" & "build_number" fields in DeciderContext()
+
+    """
+    def __init__(
+        self,
+        path: str,
+        event_logger: Optional[EventLogger] = None,
+        timeout: Optional[float] = None,
+        backoff: Optional[float] = None,
+        request_field_extractor: Callable[[BaseplateRequest], Dict[str, str]] = None
+    ):
+        self._filewatcher = FileWatcher(path=path, parser=init_decider_parser, timeout=timeout, backoff=backoff)
+        self._event_logger = event_logger
+        self._request_field_extractor = request_field_extractor
+
+    @classmethod
+    def is_employee(cls, edge_context: Any) -> bool:
+        return (
+            any([edge_context.user.has_role(role) for role in EMPLOYEE_ROLES])
+            if edge_context.user.is_logged_in
+            else False
+        )
+
+    def make_object_for_context(self, name: str, span: Span) -> "Decider":
+        try:
+            _ = self._filewatcher.get_data()
+        except WatchedFileNotAvailableError as exc:
+            logger.warning("Experiment config unavailable: %s", str(exc))
+        except TypeError as exc:
+            logger.warning("Could not load experiment config: %s", str(exc))
+
+        request = span.context
+        ec = request.edgecontext
+
+        if self._request_field_extractor:
+            extracted_fields = self._request_field_extractor(request)
+        else:
+            extracted_fields = {}
+
+        event_fields = ec.user.event_fields()
+        try:
+            decider_context = DeciderContext(
+                user_id=ec.user.id,
+                loid=ec.loid.id,
+                country_code=ec.geolocation.country_code,
+                user_is_employee=DeciderContextFactory.is_employee(ec),
+                logged_in=ec.user.is_logged_in,
+                device_id=ec.device.id,
+                request_url=request.request_url,
+                authentication_token=ec.authentication_token,
+                app_name=extracted_fields.get("app_name"),
+                build_number=extracted_fields.get("build_number"),
+                cookie_created_timestamp=event_fields.get("cookie_created_timestamp"),
+                event_fields=event_fields,
+            )
+        except Exception as exc:
+            logger.warning("Could not create full DeciderContext(): %s", str(exc))
+            logger.warning("defaulting to DeciderContext() with only user_id.")
+            decider_context = DeciderContext(user_id=ec.user.id)
+
+        return Decider(
+            decider_context=decider_context,
+            config_watcher=self._filewatcher,
+            server_span=span,
+            context_name=name,
+            event_logger=self._event_logger,
+        )
+
+
+class Decider:
+    """Access to experiments with automatic refresh when changed.
+
+    This experiments client allows access to the experiments cached on disk by
+    the experiment configuration fetcher daemon.  It will automatically reload
+    the cache when changed.  This client also handles logging bucketing events
+    to the event pipeline when it is determined that the request is part of an
+    active variant.
+    """
+
+    def __init__(
+        self,
+        decider_context: DeciderContext,
+        config_watcher: FileWatcher,
+        server_span: Span,
+        context_name: str,
+        event_logger: Optional[EventLogger] = None,
+    ):
+        self._decider_context = decider_context
+        self._config_watcher = config_watcher
+        self._span = server_span
+        self._context_name = context_name
+        if event_logger:
+            self._event_logger = event_logger
+        else:
+            self._event_logger = DebugLogger()
+
+    def _get_decider(self):
+        try:
+            return self._config_watcher.get_data()
+        except WatchedFileNotAvailableError as exc:
+            logger.warning("Experiment config unavailable: %s", str(exc))
+        except TypeError as exc:
+            logger.warning("Could not load experiment config: %s", str(exc))
+        return None
+
+    def get_variant(
+        self,
+        experiment_name: Optional[str] = None,
+        **exposure_kwargs: Optional[Dict[str, Any]]
+    ) -> Optional[str]:
+        r"""Return a bucketing variant, if any.
+
+        Since calling get_variant)() will fire an exposure event, it
+        is best to call this when you are making the decision that
+        will expose the experiment to the user.  If you absolutely must check
+        the status of an experiment before you are sure that the experiment
+        will be exposed to the user, you can use `get_variant_without_expose()` to
+        disabled exposure events for that check and call `expose()` manually later.
+
+        :param experiment_name: Name of the experiment you want to run.
+
+        :param exposure_kwargs:  Addiotional arguments that will be passed to expose().
+
+        :return: Variant name if a variant is assigned, None otherwise.
+
+        """
+        decider = self._get_decider()
+        if decider is None:
+            logger.warning("Rust decider did not initialize.")
+            return None
+
+        # `choose()` is executed in Rust Decider lib
+        #  https://github.snooguts.net/reddit/decider
+        ctx = rust_decider.make_ctx(self._decider_context.to_dict())
+        choice = decider.choose(experiment_name, ctx)
+        error = choice.err()
+        variant = choice.decision()
+
+        if error:
+            logger.warning(f"Encountered error in Rust Decider: {error}")
+            return None
+        else:
+            pass
+            # inputs = self._decider_context.get_event_fields()
+            # inputs.update(exposure_kwargs or {})
+            # for event in choice.events:
+            #     decider event:
+            #     “experiment_id:experiment_name:experiment_version:variant_name:bucket_val:start_ts:stop_ts:owner:event_type"
+            #     id, name, version, variant, bucket_val, start_ts, stop_ts, owner, event_type = event.split(“:”)
+            #     experiment = ExperimentConfig(
+            #         id=id,
+            #         name=name,
+            #         version=version,
+            #         variant=variant,
+            #         bucket_val=bucket_val,
+            #         start_ts=start_ts,
+            #         stop_ts=stop_ts,
+            #         owner=owner
+            #     )
+            #     context_fields = self._decider_context.to_dict()
+            #
+            #     # make work with these fields
+            #     # https://github.snooguts.net/reddit/reddit-service-graphql/blob/3c5b239755b8ffb5770bfaa5ef5f5fd9e5e10635/graphql-py/graphql_api/events/utils.py#L218-L244
+            #     self._event_logger.log(
+            #         experiment=experiment,
+            #         variant=variant,
+            #         span=self._span,
+            #         event_type=EVENT_TYPE,
+            #         inputs=inputs,
+            #         **context_fields,
+            #     )
+
+        return variant
+
+    def get_variant_without_expose(self, experiment_name: str) -> Optional[str]:
+        decider = self._get_decider()
+        if decider is None:
+            logger.warning("Rust decider did not initialize.")
+            return None
+
+        # `choose()` is executed in Rust Decider lib
+        #  https://github.snooguts.net/reddit/decider
+        choice = decider.choose(experiment_name, self._decider_context.to_dict())
+        error = choice.err()
+        variant = choice.decision()
+
+        if error:
+            logger.warning(f"Encountered error in Rust Decider: {error}")
+            return None
+        else:
+            pass
+            # context_fields = self._decider_context.to_dict()
+            # inputs = self._decider_context.get_event_fields()
+            # force expose for Holdout Groups
+            # for event in choice.events:
+            #     # decider event:
+            #     “experiment_id:experiment_name:experiment_version:variant_name:bucket_val:start_ts:stop_ts:owner:event_type"
+            #     id, name, version, variant, bucket_val, start_ts, stop_ts, owner, event_type = event.split(“:”)
+            #     if event_type == "1": # 0 for primary, 1 for Holdout
+            #         experiment = ExperimentConfig(
+            #             id=id,
+            #             name=name,
+            #             version=version,
+            #             variant=variant,
+            #             bucket_val=bucket_val,
+            #             start_ts=start_ts,
+            #             stop_ts=stop_ts,
+            #             owner=owner
+            #         )
+            #         self._event_logger.log(
+            #             experiment=experiment,
+            #             variant=variant,
+            #             span=self._span,
+            #             event_type=EVENT_TYPE,
+            #             inputs=inputs,
+            #             **context_fields,
+            #         )
+
+        return variant
+
+    def expose(
+        self, experiment_name: str, variant_name: str, **exposure_kwargs: Optional[Dict[str, Any]]
+    ) -> None:
+        """Log an event to indicate that a user has been exposed to an experimental treatment.
+
+        :param experiment_name: Name of the experiment that was exposed.
+        :param variant_name: Name of the variant that was exposed.
+        :param exposure_kwargs: Additional arguments that will be passed to logger under "inputs" key.
+
+        """
+        # context_fields = self._decider_context.to_dict()
+        # inputs = self._decider_context.get_event_fields()
+        # inputs.update(exposure_kwargs or {})
+
+        # todo: either implement `rust_decider.get_experiment(experiment_name)`
+        # or get experiment from json.parse(file.name) in `init_decider_parser()`
+        #
+        # experiment_fields = self.get_decider.get_experiment_fields()
+        # experiment = ExperimentConfig(**experiment_fields)
+        # self._event_logger.log(
+        #     experiment=experiment,
+        #     variant=variant_name,
+        #     span=self._span,
+        #     event_type=EVENT_TYPE,
+        #     inputs=inputs,
+        #     **context_fields,
+        # )
+
+
+class DeciderClient(config.Parser):
+    """Configure an experiments client.
+
+    This is meant to be used with
+    :py:meth:`baseplate.Baseplate.configure_context`.
+
+    See :py:func:`decider_client_from_config` for available configuration settings.
+
+    :param event_logger: The EventLogger instance to be used to log bucketing events.
+
+    :param request_field_extractor: an optional function used to populate
+        "app_name" & "build_number" fields in DeciderContext()
+    """
+
+    def __init__(
+        self,
+        event_logger: EventLogger,
+        request_field_extractor: Callable[[BaseplateRequest], Dict[str, str]] = None
+    ):
+        self.event_logger = event_logger
+        self.request_field_extractor = request_field_extractor
+
+    def parse(self, key_path: str, raw_config: config.RawConfig) -> DeciderContextFactory:
+        return decider_client_from_config(
+            app_config=raw_config,
+            event_logger=self.event_logger,
+            prefix=f"{key_path}.",
+            request_field_extractor=self.request_field_extractor
+        )
+
+
+def decider_client_from_config(
+    app_config: config.RawConfig,
+    event_logger: EventLogger,
+    prefix: str = "experiments.",
+    request_field_extractor: Callable[[BaseplateRequest], Dict[str, str]] = None
+) -> DeciderContextFactory:
+    """Configure and return an :py:class:`DeciderContextFactory` object.
+
+    The keys useful to :py:func:`decider_client_from_config` should be prefixed, e.g.
+    ``experiments.path``, etc.
+
+    Supported keys:
+
+    ``path`` (optional)
+        The path to the experiment configuration file generated by the
+        experiment configuration fetcher daemon.
+    ``timeout`` (optional)
+        The time that we should wait for the file specified by ``path`` to
+        exist.  Defaults to `None` which is `infinite`.
+    ``backoff`` (optional)
+        The base amount of time for exponential backoff when trying to find the
+        experiments config file. Defaults to no backoff between tries.
+    ``request_field_extractor`` (optional) used to populate
+        "app_name" & "build_number" fields in DeciderContext()
+
+    :param raw_config: The application configuration which should have
+        settings for the experiments client.
+    :param event_logger: The EventLogger to be used to log bucketing events.
+    :param prefix: the prefix used to filter keys (defaults to "experiments.").
+
+    """
+    assert prefix.endswith(".")
+    config_prefix = prefix[:-1]
+
+    cfg = config.parse_config(
+        app_config,
+        {
+            config_prefix: {
+                "path": config.Optional(config.String, default="/var/local/experiments.json"),
+                "timeout": config.Optional(config.Timespan),
+                "backoff": config.Optional(config.Timespan),
+            }
+        },
+    )
+    options = getattr(cfg, config_prefix)
+
+    # pylint: disable=maybe-no-member
+    if options.timeout:
+        timeout = options.timeout.total_seconds()
+    else:
+        timeout = None
+
+    if options.backoff:
+        backoff = options.backoff.total_seconds()
+    else:
+        backoff = None
+
+    return DeciderContextFactory(
+        path=options.path,
+        event_logger=event_logger,
+        timeout=timeout,
+        backoff=backoff,
+        request_field_extractor=request_field_extractor
+    )

--- a/reddit_decider/__init__.py
+++ b/reddit_decider/__init__.py
@@ -120,7 +120,7 @@ class Decider:
     ) -> Optional[str]:
         """Return a bucketing variant, if any, with auto-exposure.
 
-        Since calling get_variant)() will fire an exposure event, it
+        Since calling get_variant() will fire an exposure event, it
         is best to call this when you are making the decision that
         will expose the experiment to the user.
         If you absolutely must check the status of an experiment

--- a/reddit_decider/__init__.py
+++ b/reddit_decider/__init__.py
@@ -30,6 +30,7 @@ class DeciderContext:
         self,
         user_id: str,
         country_code: Optional[str] = None,
+        locale: Optional[str] = None,
         user_is_employee: Optional[bool] = None,
         logged_in: Optional[bool] = None,
         device_id: Optional[str] = None,
@@ -37,10 +38,12 @@ class DeciderContext:
         authentication_token: Optional[str] = None,
         app_name: Optional[str] = None,
         build_number: Optional[str] = None,
+        origin_service: Optional[str] = None,
         cookie_created_timestamp: Optional[float] = None,
     ):
         self._user_id = user_id
         self._country_code = country_code
+        self._locale = locale
         self._user_is_employee = user_is_employee
         self._logged_in = logged_in
         self._device_id = device_id
@@ -48,6 +51,7 @@ class DeciderContext:
         self._authentication_token = authentication_token
         self._app_name = app_name
         self._build_number = build_number
+        self._origin_service = origin_service
         self._cookie_created_timestamp = cookie_created_timestamp
 
 
@@ -55,6 +59,7 @@ class DeciderContext:
         return {
             "user_id": self._user_id,
             "country_code": self._country_code,
+            "locale": self._locale,
             "user_is_employee": self._user_is_employee,
             "logged_in": self._logged_in,
             "device_id": self._device_id,
@@ -62,6 +67,7 @@ class DeciderContext:
             "authentication_token": self._authentication_token,
             "app_name": self._app_name,
             "build_number": self._build_number,
+            "origin_service": self._origin_service,
             "cookie_created_timestamp": self._cookie_created_timestamp,
         }
 
@@ -247,6 +253,8 @@ class DeciderContextFactory(ContextFactory):
                 user_id=user_event_fields.get("user_id"),
                 logged_in=user_event_fields.get("logged_in"),
                 country_code=ec.geolocation.country_code,
+                locale=ec.locale.locale_code,
+                origin_service=ec.origin_service.name,
                 user_is_employee=DeciderContextFactory.is_employee(ec),
                 device_id=ec.device.id,
                 request_url=request.request_url,

--- a/reddit_decider/__init__.py
+++ b/reddit_decider/__init__.py
@@ -77,7 +77,7 @@ def init_decider_parser(file):
 
 def validate_decider(decider: Optional[Any]) -> None:
     if decider is None:
-        logger.error(f"Rust decider did not initialize.")
+        logger.error(f"Rust decider is None--did not initialize.")
 
     if decider:
         decider_err = decider.err()
@@ -112,13 +112,12 @@ class Decider:
             self._event_logger = DebugLogger()
 
     def _get_decider(self):
-        decider = None
         try:
             decider = self._config_watcher.get_data()
             validate_decider(decider)
             return decider
         except WatchedFileNotAvailableError as exc:
-            logger.error("Experiment config unavailable: %s", str(exc))
+            logger.error("Experiment config file unavailable: %s", str(exc))
         except TypeError as exc:
             logger.error("Could not load experiment config: %s", str(exc))
         return None

--- a/reddit_decider/__init__.py
+++ b/reddit_decider/__init__.py
@@ -34,7 +34,6 @@ class DeciderContext:
         user_is_employee: Optional[bool] = None,
         logged_in: Optional[bool] = None,
         device_id: Optional[str] = None,
-        request_url: Optional[str] = None,
         authentication_token: Optional[str] = None,
         app_name: Optional[str] = None,
         build_number: Optional[str] = None,
@@ -47,7 +46,6 @@ class DeciderContext:
         self._user_is_employee = user_is_employee
         self._logged_in = logged_in
         self._device_id = device_id
-        self._request_url = request_url
         self._authentication_token = authentication_token
         self._app_name = app_name
         self._build_number = build_number
@@ -63,7 +61,6 @@ class DeciderContext:
             "user_is_employee": self._user_is_employee,
             "logged_in": self._logged_in,
             "device_id": self._device_id,
-            "request_url": self._request_url,
             "authentication_token": self._authentication_token,
             "app_name": self._app_name,
             "build_number": self._build_number,
@@ -269,7 +266,6 @@ class DeciderContextFactory(ContextFactory):
                 origin_service=ec.origin_service.name,
                 user_is_employee=DeciderContextFactory.is_employee(ec),
                 device_id=ec.device.id,
-                request_url=request.request_url,
                 authentication_token=ec.authentication_token,
                 app_name=extracted_fields.get("app_name"),
                 build_number=extracted_fields.get("build_number"),

--- a/reddit_decider/__init__.py
+++ b/reddit_decider/__init__.py
@@ -118,9 +118,9 @@ class Decider:
             validate_decider(decider)
             return decider
         except WatchedFileNotAvailableError as exc:
-            logger.warning("Experiment config unavailable: %s", str(exc))
+            logger.error("Experiment config unavailable: %s", str(exc))
         except TypeError as exc:
-            logger.warning("Could not load experiment config: %s", str(exc))
+            logger.error("Could not load experiment config: %s", str(exc))
         return None
 
     def get_variant(
@@ -147,18 +147,17 @@ class Decider:
         """
         decider = self._get_decider()
 
-        # `choose()` is executed in Rust Decider lib
         ctx = rust_decider.make_ctx(self._decider_context.to_dict())
         ctx_err = ctx.err()
         if ctx_err is not None:
-            logger.warning(f"Encountered error creating Rust PyContext: {ctx_err}")
+            logger.warning(f"Encountered error in rust_decider.make_ctx(): {ctx_err}")
 
         choice = decider.choose(experiment_name, ctx)
         error = choice.err()
         variant = choice.decision()
 
         if error:
-            logger.warning(f"Encountered error in Rust Decider: {error}")
+            logger.warning(f"Encountered error in decider.choose(): {error}")
             return None
         else:
             pass

--- a/requirements-transitive.txt
+++ b/requirements-transitive.txt
@@ -9,7 +9,7 @@ click==7.1.2
 coverage==5.3.1
 docutils==0.16
 gevent==20.12.0
-greenlet==0.4.17
+greenlet==1.1.1
 idna==2.10
 imagesize==1.2.0
 iniconfig==1.1.1

--- a/requirements-transitive.txt
+++ b/requirements-transitive.txt
@@ -41,7 +41,7 @@ sphinxcontrib-qthelp==1.0.3
 sphinxcontrib-serializinghtml==1.1.4
 thrift==0.13.0
 toml==0.10.2
-typed-ast==1.4.2
+typed-ast==1.4.3
 typing-extensions==3.7.4.3
 urllib3==1.26.2
 zope.event==4.5.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 alabaster==0.7.12
 baseplate==2.0.0a1
 black==21.4b2
-reddit-decider==1.0.12
+reddit-decider==1.0.14
 flake8==3.9.1
 mypy==0.790
 pyramid==2.0   # required for `from baseplate.frameworks.pyramid import BaseplateRequest` which calls `import pyramid.events`

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 alabaster==0.7.12
 baseplate==2.0.0a1
 black==21.4b2
-reddit-decider==1.0.15
+reddit-decider==1.0.16
 flake8==3.9.1
 mypy==0.790
 pyramid==2.0   # required for `from baseplate.frameworks.pyramid import BaseplateRequest` which calls `import pyramid.events`

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ flake8==3.9.1
 mypy==0.790
 pyramid==2.0   # required for `from baseplate.frameworks.pyramid import BaseplateRequest` which calls `import pyramid.events`
 pydocstyle==5.1.1
-pytest==6.2.1
+pytest==6.2.5
 pytest-cov==2.10.1
 reorder-python-imports==2.3.6
 Sphinx==3.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,10 +2,10 @@
 alabaster==0.7.12
 baseplate==2.0.0a1
 black==21.4b2
-#decider-py==0.0.3 currently uploaded only to test.pypi.org/project/decider-py, uncomment when uploaded to non-test pypi.org
+reddit-decider==1.0.12
 flake8==3.9.1
 mypy==0.790
-pyramid==2.0 # required for `from baseplate.frameworks.pyramid import BaseplateRequest` which calls `import pyramid.events`
+pyramid==2.0   # required for `from baseplate.frameworks.pyramid import BaseplateRequest` which calls `import pyramid.events`
 pydocstyle==5.1.1
 pytest==6.2.1
 pytest-cov==2.10.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,8 +2,10 @@
 alabaster==0.7.12
 baseplate==2.0.0a1
 black==21.4b2
+#decider-py==0.0.3 currently uploaded only to test.pypi.org/project/decider-py, uncomment when uploaded to non-test pypi.org
 flake8==3.9.1
 mypy==0.790
+pyramid==2.0 # required for `from baseplate.frameworks.pyramid import BaseplateRequest` which calls `import pyramid.events`
 pydocstyle==5.1.1
 pytest==6.2.1
 pytest-cov==2.10.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 alabaster==0.7.12
 baseplate==2.0.0a1
 black==21.4b2
-reddit-decider==1.0.14
+reddit-decider==1.0.15
 flake8==3.9.1
 mypy==0.790
 pyramid==2.0   # required for `from baseplate.frameworks.pyramid import BaseplateRequest` which calls `import pyramid.events`

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,7 +10,6 @@ exclude =
     .eggs/
 
 [mypy]
-python_version = 3.6
 warn_unused_configs = True
 disallow_any_generics = False
 disallow_subclassing_any = True

--- a/tests/decider_tests.py
+++ b/tests/decider_tests.py
@@ -64,7 +64,6 @@ class DeciderContextFactoryTests(unittest.TestCase):
     authentication_token = "token"
     country_code = "US"
     device_id = "abc"
-    request_url = "www.reddit.com/"
     cookie_created_timestamp = 1234
     locale_code = "us_en"
     origin_service = "origin"
@@ -88,7 +87,6 @@ class DeciderContextFactoryTests(unittest.TestCase):
         self.mock_span.context.edgecontext.locale.locale_code = self.locale_code
         self.mock_span.context.edgecontext.origin_service.name = self.origin_service
         self.mock_span.context.edgecontext.device.id = self.device_id
-        self.mock_span.context.request_url = self.request_url
 
     def test_make_object_for_context_and_decider_context(self, file_watcher_mock):
         decider_ctx_factory = decider_client_from_config(
@@ -108,10 +106,8 @@ class DeciderContextFactoryTests(unittest.TestCase):
         self.assertEqual(decider_ctx_dict["user_is_employee"], True)
         self.assertEqual(decider_ctx_dict["logged_in"], self.is_logged_in)
         self.assertEqual(decider_ctx_dict["device_id"], self.device_id)
-        self.assertEqual(decider_ctx_dict["request_url"], self.request_url)
         self.assertEqual(decider_ctx_dict["locale"], self.locale_code)
         self.assertEqual(decider_ctx_dict["origin_service"], self.origin_service)
-        self.assertEqual(decider_ctx_dict["request_url"], self.request_url)
         self.assertEqual(decider_ctx_dict["authentication_token"], self.authentication_token)
         self.assertEqual(
             decider_ctx_dict["app_name"], None

--- a/tests/decider_tests.py
+++ b/tests/decider_tests.py
@@ -12,9 +12,9 @@ from reddit_edgecontext import AuthenticationToken
 from reddit_edgecontext import User
 
 from reddit_decider import Decider
+from reddit_decider import decider_client_from_config
 from reddit_decider import DeciderContext
 from reddit_decider import DeciderContextFactory
-from reddit_decider import decider_client_from_config
 from reddit_decider import init_decider_parser
 
 
@@ -37,7 +37,8 @@ class DeciderClientFromConfigTests(unittest.TestCase):
 
     def test_timeout(self, file_watcher_mock):
         decider_ctx_factory = decider_client_from_config(
-            {"experiments.path": "/tmp/test", "experiments.timeout": "60 seconds"}, self.event_logger
+            {"experiments.path": "/tmp/test", "experiments.timeout": "60 seconds"},
+            self.event_logger,
         )
         self.assertIsInstance(decider_ctx_factory, DeciderContextFactory)
         file_watcher_mock.assert_called_once_with(
@@ -92,17 +93,24 @@ class DeciderContextFactoryTests(unittest.TestCase):
         self.assertIsInstance(decider_context, DeciderContext)
 
         decider_ctx_dict = decider_context.to_dict()
-        self.assertEqual(decider_ctx_dict['user_id'], self.user_id)
-        self.assertEqual(decider_ctx_dict['country_code'], self.country_code)
-        self.assertEqual(decider_ctx_dict['user_is_employee'], True)
-        self.assertEqual(decider_ctx_dict['logged_in'], self.is_logged_in)
-        self.assertEqual(decider_ctx_dict['device_id'], self.device_id)
-        self.assertEqual(decider_ctx_dict['request_url'], self.request_url)
-        self.assertEqual(decider_ctx_dict['authentication_token'], self.authentication_token)
-        self.assertEqual(decider_ctx_dict['app_name'], None)      # requires request_field_extractor param
-        self.assertEqual(decider_ctx_dict['build_number'], None)  # requires request_field_extractor param
-        self.assertEqual(decider_ctx_dict['loid'], self.loid_id)
-        self.assertEqual(decider_ctx_dict['cookie_created_timestamp'], self.mock_span.context.edgecontext.user.event_fields().get("cookie_created_timestamp"))
+        self.assertEqual(decider_ctx_dict["user_id"], self.user_id)
+        self.assertEqual(decider_ctx_dict["country_code"], self.country_code)
+        self.assertEqual(decider_ctx_dict["user_is_employee"], True)
+        self.assertEqual(decider_ctx_dict["logged_in"], self.is_logged_in)
+        self.assertEqual(decider_ctx_dict["device_id"], self.device_id)
+        self.assertEqual(decider_ctx_dict["request_url"], self.request_url)
+        self.assertEqual(decider_ctx_dict["authentication_token"], self.authentication_token)
+        self.assertEqual(
+            decider_ctx_dict["app_name"], None
+        )  # requires request_field_extractor param
+        self.assertEqual(
+            decider_ctx_dict["build_number"], None
+        )  # requires request_field_extractor param
+        self.assertEqual(decider_ctx_dict["loid"], self.loid_id)
+        self.assertEqual(
+            decider_ctx_dict["cookie_created_timestamp"],
+            self.mock_span.context.edgecontext.user.event_fields().get("cookie_created_timestamp"),
+        )
 
     # Todo: DeciderContext request_field_extractor tests
 
@@ -110,6 +118,7 @@ class DeciderContextFactoryTests(unittest.TestCase):
 # Todo: test DeciderClient()
 # @mock.patch("reddit_decider.FileWatcher")
 # class DeciderClientTests(unittest.TestCase):
+
 
 class TestDeciderGetVariant(unittest.TestCase):
     def setUp(self):
@@ -146,37 +155,16 @@ class TestDeciderGetVariant(unittest.TestCase):
                 "owner": "test_owner",
                 "experiment": {
                     "variants": [
-                        {
-                            "range_start": 0.0,
-                            "range_end": 0.2,
-                            "name": "control_1"
-                        },
-                        {
-                            "range_start": 0.2,
-                            "range_end": 0.4,
-                            "name": "control_2"
-                        },
-                        {
-                            "range_start": 0.4,
-                            "range_end": 0.6,
-                            "name": "variant_2"
-                        },
-                        {
-                            "range_start": 0.6,
-                            "range_end": 0.8,
-                            "name": "variant_3"
-                        },
-                        {
-                            "range_start": 0.8,
-                            "range_end": 1.0,
-                            "name": "variant_4"
-                        }
+                        {"range_start": 0.0, "range_end": 0.2, "name": "active"},
+                        {"range_start": 0.2, "range_end": 0.4, "name": "control_1"},
+                        {"range_start": 0.4, "range_end": 0.6, "name": "control_2"},
+                        {"range_start": 0.6, "range_end": 0.8, "name": "variant_3"},
                     ],
                     "experiment_version": 2,
                     "shuffle_version": 0,
                     "bucket_val": "user_id",
-                    "log_bucketing": False
-                }
+                    "log_bucketing": False,
+                },
             }
         }
 
@@ -225,28 +213,12 @@ class TestDeciderGetVariant(unittest.TestCase):
                     "id": 1,
                     "name": "test",
                     "variants": [
-                        {
-                            "range_start": 0.0,
-                            "range_end": 0.2,
-                            "name": "active"
-                        },
-                        {
-                            "range_start": 0.2,
-                            "range_end": 0.4,
-                            "name": "control_1"
-                        },
-                        {
-                            "range_start": 0.4,
-                            "range_end": 0.6,
-                            "name": "control_2"
-                        },
-                        {
-                            "range_start": 0.6,
-                            "range_end": 0.8,
-                            "name": "variant_3"
-                        }
-                    ]
-                }
+                        {"range_start": 0.0, "range_end": 0.2, "name": "active"},
+                        {"range_start": 0.2, "range_end": 0.4, "name": "control_1"},
+                        {"range_start": 0.4, "range_end": 0.6, "name": "control_2"},
+                        {"range_start": 0.6, "range_end": 0.8, "name": "variant_3"},
+                    ],
+                },
             }
         }
         with self.create_temp_config_file(config) as f:
@@ -307,6 +279,7 @@ class TestDeciderGetVariant(unittest.TestCase):
     # Todo: test exposure_kwargs
 
     # Todo: test un-enabled experiment
+
 
 # Todo: test get_variant_without_expose()
 # class TestDeciderGetVariantWithoutExpose(unittest.TestCase):

--- a/tests/decider_tests.py
+++ b/tests/decider_tests.py
@@ -66,6 +66,8 @@ class DeciderContextFactoryTests(unittest.TestCase):
     device_id = "abc"
     request_url = "www.reddit.com/"
     cookie_created_timestamp = 1234
+    locale_code = "us_en"
+    origin_service = "origin"
     event_fields = {
         "user_id": user_id,
         "logged_in": is_logged_in,
@@ -83,6 +85,8 @@ class DeciderContextFactoryTests(unittest.TestCase):
         )
         self.mock_span.context.edgecontext.authentication_token = self.authentication_token
         self.mock_span.context.edgecontext.geolocation.country_code = self.country_code
+        self.mock_span.context.edgecontext.locale.locale_code = self.locale_code
+        self.mock_span.context.edgecontext.origin_service.name = self.origin_service
         self.mock_span.context.edgecontext.device.id = self.device_id
         self.mock_span.context.request_url = self.request_url
 
@@ -104,6 +108,9 @@ class DeciderContextFactoryTests(unittest.TestCase):
         self.assertEqual(decider_ctx_dict["user_is_employee"], True)
         self.assertEqual(decider_ctx_dict["logged_in"], self.is_logged_in)
         self.assertEqual(decider_ctx_dict["device_id"], self.device_id)
+        self.assertEqual(decider_ctx_dict["request_url"], self.request_url)
+        self.assertEqual(decider_ctx_dict["locale"], self.locale_code)
+        self.assertEqual(decider_ctx_dict["origin_service"], self.origin_service)
         self.assertEqual(decider_ctx_dict["request_url"], self.request_url)
         self.assertEqual(decider_ctx_dict["authentication_token"], self.authentication_token)
         self.assertEqual(

--- a/tests/decider_tests.py
+++ b/tests/decider_tests.py
@@ -155,10 +155,11 @@ class TestDeciderGetVariant(unittest.TestCase):
                 "owner": "test_owner",
                 "experiment": {
                     "variants": [
-                        {"range_start": 0.0, "range_end": 0.2, "name": "active"},
-                        {"range_start": 0.2, "range_end": 0.4, "name": "control_1"},
-                        {"range_start": 0.4, "range_end": 0.6, "name": "control_2"},
+                        {"range_start": 0.0, "range_end": 0.2, "name": "control_1"},
+                        {"range_start": 0.2, "range_end": 0.4, "name": "control_2"},
+                        {"range_start": 0.4, "range_end": 0.6, "name": "variant_2"},
                         {"range_start": 0.6, "range_end": 0.8, "name": "variant_3"},
+                        {"range_start": 0.8, "range_end": 1.0, "name": "variant_4"},
                     ],
                     "experiment_version": 2,
                     "shuffle_version": 0,

--- a/tests/decider_tests.py
+++ b/tests/decider_tests.py
@@ -57,7 +57,7 @@ class DeciderClientFromConfigTests(unittest.TestCase):
 
 
 @mock.patch("reddit_decider.FileWatcher")
-class DeciderContextTests(unittest.TestCase):
+class DeciderContextFactoryTests(unittest.TestCase):
     user_id = "t2_1234"
     is_logged_in = True
     authentication_token = "token"

--- a/tests/decider_tests.py
+++ b/tests/decider_tests.py
@@ -78,7 +78,9 @@ class DeciderContextFactoryTests(unittest.TestCase):
         self.event_logger = mock.Mock(spec=DebugLogger)
         self.mock_span = mock.MagicMock(spec=ServerSpan)
         self.mock_span.context = mock.Mock()
-        self.mock_span.context.edgecontext.user.event_fields = mock.Mock(return_value=self.event_fields)
+        self.mock_span.context.edgecontext.user.event_fields = mock.Mock(
+            return_value=self.event_fields
+        )
         self.mock_span.context.edgecontext.authentication_token = self.authentication_token
         self.mock_span.context.edgecontext.geolocation.country_code = self.country_code
         self.mock_span.context.edgecontext.device.id = self.device_id

--- a/tests/decider_tests.py
+++ b/tests/decider_tests.py
@@ -1,0 +1,310 @@
+import contextlib
+import json
+import tempfile
+import unittest
+
+from unittest import mock
+
+from baseplate import ServerSpan
+from baseplate.lib.events import DebugLogger
+from baseplate.lib.file_watcher import FileWatcher
+from reddit_edgecontext import AuthenticationToken
+from reddit_edgecontext import User
+
+from reddit_decider import Decider
+from reddit_decider import DeciderContext
+from reddit_decider import DeciderContextFactory
+from reddit_decider import decider_client_from_config
+from reddit_decider import init_decider_parser
+
+
+class TestDecider(unittest.TestCase):
+    def setUp(self):
+        super().setUp()
+        self.event_logger = mock.Mock(spec=DebugLogger)
+        self.mock_span = mock.MagicMock(spec=ServerSpan)
+        self.mock_span.context = None
+        self.mock_authentication_token = mock.Mock(spec=AuthenticationToken)
+        self.mock_authentication_token.subject = "t2_1234"
+        self.user = User(
+            authentication_token=self.mock_authentication_token,
+            loid="t2_1",
+            cookie_created_ms=10000,
+        )
+        self.minimal_decider_context = DeciderContext(user_id=self.user.id)
+
+    @contextlib.contextmanager
+    def create_temp_config_file(self, contents):
+        with tempfile.NamedTemporaryFile() as f:
+            f.write(json.dumps(contents).encode())
+            f.seek(0)
+            yield f
+
+    def test_get_variant_expose_event_fields(self):
+        config = {
+            "exp_1": {
+                "id": 1,
+                "name": "exp_1",
+                "enabled": True,
+                "version": "2",
+                "type": "range_variant",
+                "start_ts": 37173982,
+                "stop_ts": 2147483648,
+                "owner": "test_owner",
+                "experiment": {
+                    "variants": [
+                        {
+                            "range_start": 0.0,
+                            "range_end": 0.2,
+                            "name": "control_1"
+                        },
+                        {
+                            "range_start": 0.2,
+                            "range_end": 0.4,
+                            "name": "control_2"
+                        },
+                        {
+                            "range_start": 0.4,
+                            "range_end": 0.6,
+                            "name": "variant_2"
+                        },
+                        {
+                            "range_start": 0.6,
+                            "range_end": 0.8,
+                            "name": "variant_3"
+                        },
+                        {
+                            "range_start": 0.8,
+                            "range_end": 1.0,
+                            "name": "variant_4"
+                        }
+                    ],
+                    "experiment_version": 2,
+                    "shuffle_version": 0,
+                    "bucket_val": "user_id",
+                    "log_bucketing": False
+                }
+            }
+        }
+
+        with self.create_temp_config_file(config) as f:
+            filewatcher = FileWatcher(path=f.name, parser=init_decider_parser, timeout=2, backoff=2)
+            decider = Decider(
+                decider_context=self.minimal_decider_context,
+                config_watcher=filewatcher,
+                server_span=self.mock_span,
+                context_name="test",
+                event_logger=self.event_logger,
+            )
+
+            self.assertEqual(self.event_logger.log.call_count, 0)
+            variant = decider.get_variant("exp_1")
+            self.assertEqual(variant, "variant_4")
+
+            # Todo: enable expose call
+            # self.assertEqual(self.event_logger.log.call_count, 1)
+
+            # event_fields = self.event_logger.log.call_args[1]
+            # self.assertEqual(event_fields["variant"], "variant_4")
+            # self.assertEqual(event_fields["user_id"], "t2_1234")
+            # self.assertEqual(event_fields["logged_in"], True)
+            # self.assertEqual(event_fields["app_name"], None)
+            # self.assertEqual(event_fields["cookie_created_timestamp"], 10000)
+            # self.assertEqual(event_fields["event_type"], "expose")
+            # self.assertNotEqual(event_fields["span"], None)
+
+            # self.assertEqual(getattr(event_fields["experiment"], "id"), config["id"])
+            # self.assertEqual(getattr(event_fields["experiment"], "name"), config["name"])
+            # self.assertEqual(getattr(event_fields["experiment"], "owner"), config["owner"])
+            # self.assertEqual(getattr(event_fields["experiment"], "version"), config["experiment"]["experiment_version"])
+
+    def test_none_returned_on_variant_call_with_bad_id(self):
+        config = {
+            "test": {
+                "id": "1",
+                "name": "test",
+                "owner": "test_owner",
+                "type": "r2",
+                "version": "1",
+                "start_ts": 0,
+                "stop_ts": 0,
+                "experiment": {
+                    "id": 1,
+                    "name": "test",
+                    "variants": [
+                        {
+                            "range_start": 0.0,
+                            "range_end": 0.2,
+                            "name": "active"
+                        },
+                        {
+                            "range_start": 0.2,
+                            "range_end": 0.4,
+                            "name": "control_1"
+                        },
+                        {
+                            "range_start": 0.4,
+                            "range_end": 0.6,
+                            "name": "control_2"
+                        },
+                        {
+                            "range_start": 0.6,
+                            "range_end": 0.8,
+                            "name": "variant_3"
+                        }
+                    ]
+                }
+            }
+        }
+        with self.create_temp_config_file(config) as f:
+            filewatcher = FileWatcher(path=f.name, parser=init_decider_parser, timeout=2, backoff=2)
+            decider = Decider(
+                decider_context=self.minimal_decider_context,
+                config_watcher=filewatcher,
+                server_span=self.mock_span,
+                context_name="test",
+                event_logger=self.event_logger,
+            )
+
+            variant = decider.get_variant("test")
+            self.assertEqual(self.event_logger.log.call_count, 0)
+            self.assertEqual(variant, None)
+
+    def test_none_returned_on_get_variant_call_with_no_experiment_data(self):
+        config = {
+            "test": {
+                "id": 1,
+                "name": "test",
+                "owner": "test_owner",
+                "type": "r2",
+                "version": "1",
+                "start_ts": 0,
+                "stop_ts": 0,
+            }
+        }
+        with self.create_temp_config_file(config) as f:
+            filewatcher = FileWatcher(path=f.name, parser=init_decider_parser, timeout=2, backoff=2)
+            decider = Decider(
+                decider_context=self.minimal_decider_context,
+                config_watcher=filewatcher,
+                server_span=self.mock_span,
+                context_name="test",
+                event_logger=self.event_logger,
+            )
+
+            self.assertEqual(self.event_logger.log.call_count, 0)
+            variant = decider.get_variant("test")
+            self.assertEqual(variant, None)
+
+    def test_none_returned_on_get_variant_call_with_experiment_not_found(self):
+        with self.create_temp_config_file({}) as f:
+            filewatcher = FileWatcher(path=f.name, parser=init_decider_parser, timeout=2, backoff=2)
+            decider = Decider(
+                decider_context=self.minimal_decider_context,
+                config_watcher=filewatcher,
+                server_span=self.mock_span,
+                context_name="test",
+                event_logger=self.event_logger,
+            )
+
+            self.assertEqual(self.event_logger.log.call_count, 0)
+            variant = decider.get_variant("anything")
+            self.assertEqual(variant, None)
+
+    # Todo: test exposure_kwargs
+
+    # Todo: test un-enabled experiment
+
+
+@mock.patch("reddit_decider.FileWatcher")
+class DeciderClientFromConfigTests(unittest.TestCase):
+    def setUp(self):
+        super().setUp()
+        self.event_logger = mock.Mock(spec=DebugLogger)
+        self.mock_span = mock.MagicMock(spec=ServerSpan)
+        self.mock_span.context = None
+
+    def test_make_clients(self, file_watcher_mock):
+        decider_ctx_factory = decider_client_from_config(
+            {"experiments.path": "/tmp/test"}, self.event_logger
+        )
+        self.assertIsInstance(decider_ctx_factory, DeciderContextFactory)
+        file_watcher_mock.assert_called_once_with(
+            path="/tmp/test", parser=init_decider_parser, timeout=None, backoff=None
+        )
+
+    def test_timeout(self, file_watcher_mock):
+        decider_ctx_factory = decider_client_from_config(
+            {"experiments.path": "/tmp/test", "experiments.timeout": "60 seconds"}, self.event_logger
+        )
+        self.assertIsInstance(decider_ctx_factory, DeciderContextFactory)
+        file_watcher_mock.assert_called_once_with(
+            path="/tmp/test", parser=init_decider_parser, timeout=60.0, backoff=None
+        )
+
+    def test_prefix(self, file_watcher_mock):
+        decider_ctx_factory = decider_client_from_config(
+            {"r2_experiments.path": "/tmp/test", "r2_experiments.timeout": "60 seconds"},
+            self.event_logger,
+            prefix="r2_experiments.",
+        )
+        self.assertIsInstance(decider_ctx_factory, DeciderContextFactory)
+        file_watcher_mock.assert_called_once_with(
+            path="/tmp/test", parser=init_decider_parser, timeout=60.0, backoff=None
+        )
+
+
+@mock.patch("reddit_decider.FileWatcher")
+class DeciderContextTests(unittest.TestCase):
+    user_id = "t2_1234"
+    is_logged_in = True
+    authentication_token = "token"
+    country_code = "US"
+    device_id = "abc"
+    loid_id = "loid.id"
+    request_url = "www.reddit.com/"
+
+    def setUp(self):
+        super().setUp()
+        self.event_logger = mock.Mock(spec=DebugLogger)
+        self.mock_span = mock.MagicMock(spec=ServerSpan)
+        self.mock_span.context = mock.Mock()
+        self.mock_span.context.edgecontext.user.id = self.user_id
+        self.mock_span.context.edgecontext.user.is_logged_in = self.is_logged_in
+        self.mock_span.context.edgecontext.authentication_token = self.authentication_token
+        self.mock_span.context.edgecontext.geolocation.country_code = self.country_code
+        self.mock_span.context.edgecontext.device.id = self.device_id
+        self.mock_span.context.edgecontext.loid.id = self.loid_id
+        self.mock_span.context.request_url = self.request_url
+
+    def test_make_object_for_context_and_decider_context(self, file_watcher_mock):
+        decider_ctx_factory = decider_client_from_config(
+            {"experiments.path": "/tmp/test", "experiments.timeout": "60 seconds"},
+            self.event_logger,
+            prefix="experiments.",
+        )
+        decider = decider_ctx_factory.make_object_for_context(name="test", span=self.mock_span)
+        self.assertIsInstance(decider, Decider)
+
+        decider_context = getattr(decider, "_decider_context")
+        self.assertIsInstance(decider_context, DeciderContext)
+
+        decider_ctx_dict = decider_context.to_dict()
+        self.assertEqual(decider_ctx_dict['user_id'], self.user_id)
+        self.assertEqual(decider_ctx_dict['country_code'], self.country_code)
+        self.assertEqual(decider_ctx_dict['user_is_employee'], True)
+        self.assertEqual(decider_ctx_dict['logged_in'], self.is_logged_in)
+        self.assertEqual(decider_ctx_dict['device_id'], self.device_id)
+        self.assertEqual(decider_ctx_dict['request_url'], self.request_url)
+        self.assertEqual(decider_ctx_dict['authentication_token'], self.authentication_token)
+        self.assertEqual(decider_ctx_dict['app_name'], None)      # requires request_field_extractor param
+        self.assertEqual(decider_ctx_dict['build_number'], None)  # requires request_field_extractor param
+        self.assertEqual(decider_ctx_dict['loid'], self.loid_id)
+        self.assertEqual(decider_ctx_dict['cookie_created_timestamp'], self.mock_span.context.edgecontext.user.event_fields().get("cookie_created_timestamp"))
+
+    # Todo: DeciderContext request_field_extractor tests
+
+
+# Todo: test DeciderClient()
+# @mock.patch("reddit_decider.FileWatcher")
+# class DeciderClientTests(unittest.TestCase):


### PR DESCRIPTION
# Summary 
This pr creates these classes:
- `DeciderContextFactory`   (for baseplate setup)
- `DeciderContext`                (contains all fields used for bucketing, targeting, & exposure, e.g. `"user_id"`, `"country_code"`, etc)
- `Decider`                           (contains new API: `get_variant()`)

as well as the baseplate setup convenience function:
- `decider_client_from_config()`

Todo: 
- `DeciderClient`                   (convenience class for baseplate setup)
- implement `get_variant_without_expose()`, `expose()` on `Decider`

Expose logic has been implemented but commented out because Rust Decider lib needs to return a vector of events containing all of these fields:
```
“experiment_id:experiment_name:experiment_version:variant_name:bucket_val:start_ts:stop_ts:owner:event_type"
```
for the exposure event (currently, the SDK is not `json.parse()`ing the experiment cfg json and deferring that to Rust Decider lib, so Rust has to return these fields).

# Testing
Unit tests for:
- `get_variant()`  happy path
- `get_variant()` returns `None` if the experiment's name is not in the config
- `get_variant()` returns `None` if the json config has an experiment's `id` as a str instead of an int
- `get_variant()` returns `None` if missing "experiment" key in json config

Also some basic unit test coverage of:
- `decider_client_from_config()` setup
- that `DeciderContextFactory.make_object_for_context()` correctly populates `DeciderContext` ivar  in `Decider` instance

Missing tests/todos:
- `DeciderClient`
- `get_variant_without_expose()`
- `expose()`