### PR TITLE
Build rust_py Dockerimage workflow

### DIFF
--- a/.github/workflows/rust_py-img-publish.yaml
+++ b/.github/workflows/rust_py-img-publish.yaml
@@ -1,0 +1,47 @@
+name: Publish rust_py Docker image
+
+on:
+  workflow_dispatch:
+    inputs:
+      rust_version:
+        description: 'Version of Rust to use in Dockerfile'
+        required: true
+        default: 1.59
+      python_version:
+        description: 'Version of Python to use in Dockerfile'
+        required: true
+        default: 3.9
+
+jobs:
+  push_to_gh_registry:
+      name: Push Docker image to GitHub Packages
+      runs-on: ubuntu-latest
+
+      steps:
+        - name: Check out the repo
+          uses: actions/checkout@v2
+
+        - name: Set up QEMU
+          uses: docker/setup-qemu-action@v1
+
+        - name: Set up Docker Buildx
+          uses: docker/setup-buildx-action@v1
+
+        - name: Log in to GitHub Container Registry
+          uses: docker/login-action@v1
+          with:
+            registry: ghcr.io
+            username: ${{ secrets.CR_USER }}
+            password: ${{ secrets.CR_PAT }}
+
+        - name: Build and push
+          uses: docker/build-push-action@v2
+          with:
+            context: .
+            file: ./Dockerfile.rust_py
+            push: true
+            build-args: |
+              rust_version=${{ github.event.inputs.rust_version }}
+              python_version=${{ github.event.inputs.python_version }}
+            tags: |
+              ghcr.io/reddit/rust_py:${{ github.event.inputs.rust_version }}_${{ github.event.inputs.python_version }}

--- a/Dockerfile.rust_py
+++ b/Dockerfile.rust_py
@@ -1,0 +1,24 @@
+ARG python_version=3.9
+FROM python:${python_version}-slim-buster
+
+# run apt updates because the base image is on a week+ update schedule
+RUN apt-get update && apt-get upgrade -y && rm -rf /var/lib/apt/lists/
+
+RUN pip install --no-cache-dir pip==20.2.3 && \
+    python -m venv /usr/local/lib/venv && \
+    /usr/local/lib/venv/bin/pip install --no-cache-dir setuptools==47.1.0 wheel==0.36.2
+
+ENV PATH /usr/local/lib/venv/bin:$PATH
+
+WORKDIR /drone/src
+
+# enable venv for `maturin develop`
+ENV VIRTUAL_ENV=/opt/venv
+RUN python -m venv $VIRTUAL_ENV
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+
+# install rust for `maturin develop`
+ARG rust_version=1.59.0
+RUN apt-get update && apt-get install gcc -y && apt-get install -y curl && rm -rf /var/lib/apt/lists/*
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal --default-toolchain=${rust_version}
+ENV PATH="/root/.cargo/bin:${PATH}"


### PR DESCRIPTION
create python base images with rust installed.
Both python & rust versions are parameterized.

images will be pulled in ci from like so for rust version 1.59 & python version 3.9:
`ghcr.io/reddit/rust_py:1.59_3.9`

Based this approach on [this file](https://github.com/reddit/thrift-compiler/blob/main/.github/workflows/docker-publish.yaml).
in combination with how to [manually trigger the workflow with custom parameters](https://github.blog/changelog/2020-07-06-github-actions-manual-triggers-with-workflow_dispatch/)