### PR TITLE
Fix no error logging spam

### DIFF
--- a/reddit_decider/__init__.py
+++ b/reddit_decider/__init__.py
@@ -79,7 +79,8 @@ def validate_decider(decider: Optional[Any]) -> None:
 
     if decider:
         decider_err = decider.err()
-        logger.error(f"Rust decider has error: {decider_err}")
+        if decider_err:
+            logger.error(f"Rust decider has error: {decider_err}")
 
 
 class Decider:
@@ -242,6 +243,7 @@ class DeciderContextFactory(ContextFactory):
         )
 
     def make_object_for_context(self, name: str, span: Span) -> Decider:
+        decider = None
         try:
             decider = self._filewatcher.get_data()
         except WatchedFileNotAvailableError as exc:


### PR DESCRIPTION
where there's no error from decider, we don't need send logging.
```
Apr 22 12:22:24 reddit-service-experiment-config-6449948dc-llx8x reddit-service-experiment-config ERROR Rust decider has error: None
Apr 22 12:22:24 reddit-service-experiment-config-6449948dc-llx8x reddit-service-experiment-config ERROR Rust decider has error: None
```
also fix one of the small bug where decider is not initialized. 