### PR TITLE
Expose decider's vector of events in get_variant() 

### DIFF
--- a/reddit_decider/__init__.py
+++ b/reddit_decider/__init__.py
@@ -1,5 +1,7 @@
 import logging
 
+from dataclasses import dataclass
+from enum import Enum
 from typing import Any, Callable, Dict, IO, Optional
 
 from baseplate import RequestContext
@@ -19,8 +21,20 @@ import rust_decider
 logger = logging.getLogger(__name__)
 
 EMPLOYEE_ROLES = ("employee", "contractor")
-EVENT_TYPE = "expose"
 
+class EventType(Enum):
+    EXPOSE = "expose"
+
+@dataclass
+class ExperimentConfig:
+    id: int
+    version: str
+    name: str
+    variant: str
+    bucket_val: str
+    start_ts: int
+    stop_ts: int
+    owner: str
 
 class DeciderContext:
     """DeciderContext() is used to contain all fields necessary for
@@ -165,35 +179,32 @@ class Decider:
             logger.warning(f"Encountered error in decider.choose(): {error}")
             return None
         else:
-            pass
             variant = choice.decision()
-            # todo: implement expose (requires rust updates)
-            # inputs = context_fields.update(exposure_kwargs or {})
-            # for event in choice.events:
-            #     decider event:
-            #     “experiment_id:experiment_name:experiment_version:variant_name:bucket_val:start_ts:stop_ts:owner:event_type"
-            #     id, name, version, variant, bucket_val, start_ts, stop_ts, owner, event_type = event.split(“:”)
-            #     experiment = ExperimentConfig(
-            #         id=id,
-            #         name=name,
-            #         version=version,
-            #         variant=variant,
-            #         bucket_val=bucket_val,
-            #         start_ts=start_ts,
-            #         stop_ts=stop_ts,
-            #         owner=owner
-            #     )
-            #
-            #     # make work with these fields
-            #     # https://github.snooguts.net/reddit/reddit-service-graphql/blob/3c5b239755b8ffb5770bfaa5ef5f5fd9e5e10635/graphql-py/graphql_api/events/utils.py#L218-L244
-            #     self._event_logger.log(
-            #         experiment=experiment,
-            #         variant=variant,
-            #         span=self._span,
-            #         event_type=EVENT_TYPE,
-            #         inputs=inputs,
-            #         **context_fields,
-            #     )
+
+            del context_fields["auth_client_id"]
+            context_fields.update(exposure_kwargs or {})
+
+            for event in choice.events():
+                event_type, id, name, version, event_variant, bucketing_value, bucket_val, start_ts, stop_ts, owner = event.split(":")
+                experiment = ExperimentConfig(
+                    id=int(id),
+                    name=name,
+                    version=version,
+                    variant=event_variant,
+                    bucket_val=bucket_val,
+                    start_ts=start_ts,
+                    stop_ts=stop_ts,
+                    owner=owner
+                )
+
+                self._event_logger.log(
+                    experiment=experiment,
+                    variant=event_variant,
+                    span=self._span,
+                    event_type=EventType.EXPOSE,
+                    inputs=context_fields,
+                    **context_fields,
+                )
 
             return variant
 

--- a/reddit_decider/__init__.py
+++ b/reddit_decider/__init__.py
@@ -30,7 +30,6 @@ class ExperimentConfig:
     id: int
     version: str
     name: str
-    variant: str
     bucket_val: str
     start_ts: int
     stop_ts: int
@@ -190,7 +189,6 @@ class Decider:
                     id=int(id),
                     name=name,
                     version=version,
-                    variant=event_variant,
                     bucket_val=bucket_val,
                     start_ts=start_ts,
                     stop_ts=stop_ts,

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 alabaster==0.7.12
 baseplate==2.0.0a1
 black==21.4b2
-reddit-decider==1.1.10
+reddit-decider==1.1.11
 flake8==3.9.1
 mypy==0.790
 pyramid==2.0   # required for `from baseplate.frameworks.pyramid import BaseplateRequest` which calls `import pyramid.events`

--- a/tests/decider_tests.py
+++ b/tests/decider_tests.py
@@ -15,8 +15,25 @@ from reddit_decider import Decider
 from reddit_decider import decider_client_from_config
 from reddit_decider import DeciderContext
 from reddit_decider import DeciderContextFactory
+from reddit_decider import EventType
 from reddit_decider import init_decider_parser
 from reddit_decider import decider_client_from_config
+
+user_id = "t2_1234"
+is_logged_in = True
+auth_client_id = "token"
+country_code = "US"
+device_id = "abc"
+cookie_created_timestamp = 1234
+locale_code = "us_en"
+origin_service = "origin"
+app_name = "ios"
+build_number = 1
+event_fields = {
+    "user_id": user_id,
+    "logged_in": is_logged_in,
+    "cookie_created_timestamp": cookie_created_timestamp,
+}
 
 @mock.patch("reddit_decider.FileWatcher")
 class DeciderClientFromConfigTests(unittest.TestCase):
@@ -58,20 +75,6 @@ class DeciderClientFromConfigTests(unittest.TestCase):
 
 @mock.patch("reddit_decider.FileWatcher")
 class DeciderContextFactoryTests(unittest.TestCase):
-    user_id = "t2_1234"
-    is_logged_in = True
-    auth_client_id = "token"
-    country_code = "US"
-    device_id = "abc"
-    cookie_created_timestamp = 1234
-    locale_code = "us_en"
-    origin_service = "origin"
-    event_fields = {
-        "user_id": user_id,
-        "logged_in": is_logged_in,
-        "cookie_created_timestamp": cookie_created_timestamp,
-    }
-
     def setUp(self):
         super().setUp()
 
@@ -79,14 +82,14 @@ class DeciderContextFactoryTests(unittest.TestCase):
         self.mock_span = mock.MagicMock(spec=ServerSpan)
         self.mock_span.context = mock.Mock()
         self.mock_span.context.edgecontext.user.event_fields = mock.Mock(
-            return_value=self.event_fields
+            return_value=event_fields
         )
         self.mock_span.context.edgecontext.authentication_token = mock.Mock(spec=ValidatedAuthenticationToken)
-        self.mock_span.context.edgecontext.authentication_token.oauth_client_id = self.auth_client_id
-        self.mock_span.context.edgecontext.geolocation.country_code = self.country_code
-        self.mock_span.context.edgecontext.locale.locale_code = self.locale_code
-        self.mock_span.context.edgecontext.origin_service.name = self.origin_service
-        self.mock_span.context.edgecontext.device.id = self.device_id
+        self.mock_span.context.edgecontext.authentication_token.oauth_client_id = auth_client_id
+        self.mock_span.context.edgecontext.geolocation.country_code = country_code
+        self.mock_span.context.edgecontext.locale.locale_code = locale_code
+        self.mock_span.context.edgecontext.origin_service.name = origin_service
+        self.mock_span.context.edgecontext.device.id = device_id
 
     def test_make_object_for_context_and_decider_context(self, file_watcher_mock):
         decider_ctx_factory = decider_client_from_config(
@@ -101,14 +104,14 @@ class DeciderContextFactoryTests(unittest.TestCase):
         self.assertIsInstance(decider_context, DeciderContext)
 
         decider_ctx_dict = decider_context.to_dict()
-        self.assertEqual(decider_ctx_dict["user_id"], self.user_id)
-        self.assertEqual(decider_ctx_dict["country_code"], self.country_code)
+        self.assertEqual(decider_ctx_dict["user_id"], user_id)
+        self.assertEqual(decider_ctx_dict["country_code"], country_code)
         self.assertEqual(decider_ctx_dict["user_is_employee"], True)
-        self.assertEqual(decider_ctx_dict["logged_in"], self.is_logged_in)
-        self.assertEqual(decider_ctx_dict["device_id"], self.device_id)
-        self.assertEqual(decider_ctx_dict["locale"], self.locale_code)
-        self.assertEqual(decider_ctx_dict["origin_service"], self.origin_service)
-        self.assertEqual(decider_ctx_dict["auth_client_id"], self.auth_client_id)
+        self.assertEqual(decider_ctx_dict["logged_in"], is_logged_in)
+        self.assertEqual(decider_ctx_dict["device_id"], device_id)
+        self.assertEqual(decider_ctx_dict["locale"], locale_code)
+        self.assertEqual(decider_ctx_dict["origin_service"], origin_service)
+        self.assertEqual(decider_ctx_dict["auth_client_id"], auth_client_id)
         self.assertEqual(
             decider_ctx_dict["app_name"], None
         )  # requires request_field_extractor param
@@ -134,7 +137,7 @@ class TestDeciderGetVariant(unittest.TestCase):
         self.event_logger = mock.Mock(spec=DebugLogger)
         self.mock_span = mock.MagicMock(spec=ServerSpan)
         self.mock_span.context = None
-        self.minimal_decider_context = DeciderContext(user_id="t2_1234")
+        self.minimal_decider_context = DeciderContext(user_id=user_id)
 
     @contextlib.contextmanager
     def create_temp_config_file(self, contents):
@@ -144,7 +147,7 @@ class TestDeciderGetVariant(unittest.TestCase):
             yield f
 
     def test_get_variant_expose_event_fields(self):
-        config = {
+        cfg = {
             "exp_1": {
                 "id": 1,
                 "name": "exp_1",
@@ -170,10 +173,24 @@ class TestDeciderGetVariant(unittest.TestCase):
             }
         }
 
-        with self.create_temp_config_file(config) as f:
+        with self.create_temp_config_file(cfg) as f:
             filewatcher = FileWatcher(path=f.name, parser=init_decider_parser, timeout=2, backoff=2)
+            dc = DeciderContext(
+                user_id=user_id,
+                logged_in=is_logged_in,
+                country_code=country_code,
+                locale=locale_code,
+                origin_service=origin_service,
+                user_is_employee=True,
+                device_id=device_id,
+                auth_client_id=auth_client_id,
+                app_name=app_name,
+                build_number=build_number,
+                cookie_created_timestamp=cookie_created_timestamp,
+            )
+
             decider = Decider(
-                decider_context=self.minimal_decider_context,
+                decider_context=dc,
                 config_watcher=filewatcher,
                 server_span=self.mock_span,
                 context_name="test",
@@ -184,22 +201,22 @@ class TestDeciderGetVariant(unittest.TestCase):
             variant = decider.get_variant("exp_1")
             self.assertEqual(variant, "variant_4")
 
-            # Todo: enable expose call
-            # self.assertEqual(self.event_logger.log.call_count, 1)
+            # exposure assertions
+            self.assertEqual(self.event_logger.log.call_count, 1)
+            event_fields = self.event_logger.log.call_args[1]
+            self.assertEqual(event_fields["variant"], variant)
+            self.assertEqual(event_fields["user_id"], user_id)
+            self.assertEqual(event_fields["logged_in"], is_logged_in)
+            self.assertEqual(event_fields["app_name"], app_name)
+            self.assertEqual(event_fields["cookie_created_timestamp"], cookie_created_timestamp)
+            self.assertEqual(event_fields["event_type"], EventType.EXPOSE)
+            self.assertNotEqual(event_fields["span"], None)
 
-            # event_fields = self.event_logger.log.call_args[1]
-            # self.assertEqual(event_fields["variant"], "variant_4")
-            # self.assertEqual(event_fields["user_id"], "t2_1234")
-            # self.assertEqual(event_fields["logged_in"], True)
-            # self.assertEqual(event_fields["app_name"], None)
-            # self.assertEqual(event_fields["cookie_created_timestamp"], 10000)
-            # self.assertEqual(event_fields["event_type"], "expose")
-            # self.assertNotEqual(event_fields["span"], None)
-
-            # self.assertEqual(getattr(event_fields["experiment"], "id"), config["id"])
-            # self.assertEqual(getattr(event_fields["experiment"], "name"), config["name"])
-            # self.assertEqual(getattr(event_fields["experiment"], "owner"), config["owner"])
-            # self.assertEqual(getattr(event_fields["experiment"], "version"), config["experiment"]["experiment_version"])
+            config = cfg["exp_1"]
+            self.assertEqual(getattr(event_fields["experiment"], "id"), config["id"])
+            self.assertEqual(getattr(event_fields["experiment"], "name"), config["name"])
+            self.assertEqual(getattr(event_fields["experiment"], "owner"), config["owner"])
+            self.assertEqual(getattr(event_fields["experiment"], "version"), config["version"])
 
     def test_none_returned_on_variant_call_with_bad_id(self):
         config = {

--- a/tests/decider_tests.py
+++ b/tests/decider_tests.py
@@ -147,7 +147,7 @@ class TestDeciderGetVariant(unittest.TestCase):
             yield f
 
     def test_get_variant_expose_event_fields(self):
-        cfg = {
+        config = {
             "exp_1": {
                 "id": 1,
                 "name": "exp_1",
@@ -173,7 +173,7 @@ class TestDeciderGetVariant(unittest.TestCase):
             }
         }
 
-        with self.create_temp_config_file(cfg) as f:
+        with self.create_temp_config_file(config) as f:
             filewatcher = FileWatcher(path=f.name, parser=init_decider_parser, timeout=2, backoff=2)
             dc = DeciderContext(
                 user_id=user_id,
@@ -212,11 +212,11 @@ class TestDeciderGetVariant(unittest.TestCase):
             self.assertEqual(event_fields["event_type"], EventType.EXPOSE)
             self.assertNotEqual(event_fields["span"], None)
 
-            config = cfg["exp_1"]
-            self.assertEqual(getattr(event_fields["experiment"], "id"), config["id"])
-            self.assertEqual(getattr(event_fields["experiment"], "name"), config["name"])
-            self.assertEqual(getattr(event_fields["experiment"], "owner"), config["owner"])
-            self.assertEqual(getattr(event_fields["experiment"], "version"), config["version"])
+            cfg = config["exp_1"]
+            self.assertEqual(getattr(event_fields["experiment"], "id"), cfg["id"])
+            self.assertEqual(getattr(event_fields["experiment"], "name"), cfg["name"])
+            self.assertEqual(getattr(event_fields["experiment"], "owner"), cfg["owner"])
+            self.assertEqual(getattr(event_fields["experiment"], "version"), cfg["version"])
 
     def test_none_returned_on_variant_call_with_bad_id(self):
         config = {


### PR DESCRIPTION
Tested by copy/pasting the [experiments event logger from graphql](https://github.snooguts.net/reddit/reddit-service-graphql/blob/3c5b239755b8ffb5770bfaa5ef5f5fd9e5e10635/graphql-py/graphql_api/events/utils.py#L205-L295) (altered last line to print event) and passing in:
```
context_fields = {'user_id': 't2_example', 'country_code': 'US', 'locale': 'en_US', 'user_is_employee': False, 'logged_in': True, 'device_id': 'becc50f6-ff3d-407a-aa49-fa49531363be', 'canonical_url': None, 'auth_client_id': '', 'app_name': 'experiment_config', 'build_number': 1, 'origin_service': 'experiment_config', 'cookie_created_timestamp': 100000}
```
and experiment:
```
event = "event_type:exp_id:exp_name:exp_version:variant_name:bucket_val_field:user_id:start_ts:stop_ts:owner"
event_type, id, name, version, variant, bucket_val_field, bucket_val, start_ts, stop_ts, owner = event.split(":")

experiment = ExperimentConfig(
    id=id,
    name=name,
    version=version,
    bucket_val=bucket_val,
    start_ts=start_ts,
    stop_ts=stop_ts,
    owner=owner
)
```
and calling with:
```
x = ExperimentLogger()
x.log(
    experiment=experiment,
    variant="variant_name",
    span=None,
    event_type=EventType.EXPOSE,
    inputs=context_fields,
    **context_fields,
)
```


to get:
```
{'user_id': 't2_example', 'country_code': 'US', 'locale': 'en_US', 'user_is_employee': False, 'logged_in': True, 'device_id': 'becc50f6-ff3d-407a-aa49-fa49531363be', 'canonical_url': None, 'app_name': 'experiment_config', 'build_number': 1, 'origin_service': 'experiment_config', 'cookie_created_timestamp': 100000, 'source': 'experiment', 'action': 'expose', 'noun': 'user_id', 'uuid': 'ec6f146e-6d47-4d09-90db-01c440acf84b', 'client_timestamp': 1651182327956, 'experiment': {'id': 'exp_id', 'name': 'exp_name', 'variant': 'variant_name', 'owner': 'owner', 'version': 'exp_version', 'bucketing_key': 'user_id', 'bucketing_value': 't2_example'}, 'user': {'id': 't2_example', 'logged_in': True, 'cookie_created_timestamp': 100000, 'created_timestamp': None, 'is_employee': False}, 'app': {'name': 'experiment_config'}, 'zipkin': {}}
```