### PR TITLE
Create copy of context_fields when logging

### DIFF
--- a/reddit_decider/__init__.py
+++ b/reddit_decider/__init__.py
@@ -193,8 +193,8 @@ class Decider:
                     variant=event_variant,
                     span=self._span,
                     event_type=EventType.EXPOSE,
-                    inputs=context_fields,
-                    **context_fields,
+                    inputs=context_fields.copy(),
+                    **context_fields.copy(),
                 )
 
             return variant


### PR DESCRIPTION
event_logger modifies the dict reference passed in so we need to make a copy for it to manipulate freely.