### PR TITLE
get_variant_without_expose (expose for HG)

### DIFF
--- a/reddit_decider/__init__.py
+++ b/reddit_decider/__init__.py
@@ -154,7 +154,7 @@ class Decider:
         :return: Variant name if a variant is assigned, None otherwise.
         """
         decider = self._get_decider()
-        if not decider:
+        if decider is None:
             logger.warning("Encountered error in _get_decider()")
             return None
 
@@ -199,8 +199,71 @@ class Decider:
 
             return variant
 
-    # todo:
-    # def get_variant_without_expose(self, experiment_name: str) -> Optional[str]:
+    def get_variant_without_expose(self, experiment_name: str) -> Optional[str]:
+        """Return a bucketing variant, if any, without emitting exposure event.
+
+        The `expose()` function is available to be manually called afterward.
+
+        However, experiments in Holdouts will still send an exposure for
+        the holdout parent experiment, since it is not possible to
+        manually expose the holdout later (because it's not possible to know
+        if the returned `variant` string came from the holdout or its child experiment
+        after exiting this function--`control_1` could come from either).
+
+        :param experiment_name: Name of the experiment you want to run.
+
+        :return: Variant name if a variant is assigned, None otherwise.
+        """
+        decider = self._get_decider()
+        if decider is None:
+            logger.warning("Encountered error in _get_decider()")
+            return None
+
+        context_fields = self._decider_context.to_dict()
+        ctx = rust_decider.make_ctx(context_fields)
+        ctx_err = ctx.err()
+        if ctx_err is not None:
+            logger.warning(f"Encountered error in rust_decider.make_ctx(): {ctx_err}")
+
+        choice = decider.choose(experiment_name, ctx)
+        error = choice.err()
+
+        if error:
+            logger.warning(f"Encountered error in decider.choose(): {error}")
+            return None
+        else:
+            variant = choice.decision()
+
+            del context_fields["auth_client_id"]
+
+            # expose Holdout if experiment is part of one
+            for event in choice.events():
+                event_type, id, name, version, event_variant, bucketing_value, bucket_val, start_ts, stop_ts, owner = event.split(":")
+                # event_type enum:
+                # 0: regular bucketing
+                # 1: override
+                # 2: holdout
+                if event_type == "2":
+                    experiment = ExperimentConfig(
+                        id=int(id),
+                        name=name,
+                        version=version,
+                        bucket_val=bucket_val,
+                        start_ts=start_ts,
+                        stop_ts=stop_ts,
+                        owner=owner
+                    )
+
+                    self._event_logger.log(
+                        experiment=experiment,
+                        variant=event_variant,
+                        span=self._span,
+                        event_type=EventType.EXPOSE,
+                        inputs=context_fields.copy(),
+                        **context_fields.copy(),
+                    )
+
+            return variant
 
     # todo:
     # def expose(

--- a/reddit_decider/__init__.py
+++ b/reddit_decider/__init__.py
@@ -138,15 +138,14 @@ class Decider:
     ) -> Optional[str]:
         """Return a bucketing variant, if any, with auto-exposure.
 
-        Since calling get_variant() will fire an exposure event, it
-        is best to call this when you are making the decision that
-        will expose the experiment to the user.
+        Since calling `get_variant()` will fire an exposure event, it
+        is best to call it when you are sure the user will be exposed to the experiment.
         If you absolutely must check the status of an experiment
-        before you are sure that the experiment will be exposed to the user,
-        you can use `get_variant_without_expose()` to disable exposure events
+        before the user will be exposed to the experiment,
+        use `get_variant_without_expose()` to disable exposure events
         and call `expose()` manually later.
 
-        :param experiment_name: Name of the experiment you want to run.
+        :param experiment_name: Name of the experiment you want a variant for.
 
         :param exposure_kwargs:  Additional arguments that will be passed
             to events_logger under "inputs" key.
@@ -204,13 +203,13 @@ class Decider:
 
         The `expose()` function is available to be manually called afterward.
 
-        However, experiments in Holdouts will still send an exposure for
+        However, experiments in Holdout Groups will still send an exposure for
         the holdout parent experiment, since it is not possible to
-        manually expose the holdout later (because it's not possible to know
-        if the returned `variant` string came from the holdout or its child experiment
-        after exiting this function--`control_1` could come from either).
+        manually expose the holdout later (because after exiting this function,
+        it's impossible to know if a returned `None` or `"control_1"` string
+        came from the holdout group or its child experiment).
 
-        :param experiment_name: Name of the experiment you want to run.
+        :param experiment_name: Name of the experiment you want a variant for.
 
         :return: Variant name if a variant is assigned, None otherwise.
         """
@@ -236,13 +235,13 @@ class Decider:
 
             del context_fields["auth_client_id"]
 
-            # expose Holdout if experiment is part of one
+            # expose Holdout if the experiment is part of one
             for event in choice.events():
                 event_type, id, name, version, event_variant, bucketing_value, bucket_val, start_ts, stop_ts, owner = event.split(":")
                 # event_type enum:
-                # 0: regular bucketing
-                # 1: override
-                # 2: holdout
+                #   0: regular bucketing
+                #   1: override
+                #   2: holdout
                 if event_type == "2":
                     experiment = ExperimentConfig(
                         id=int(id),

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 alabaster==0.7.12
 baseplate==2.0.0a1
 black==21.4b2
-reddit-decider==1.1.11
+reddit-decider==1.1.13
 flake8==3.9.1
 mypy==0.790
 pyramid==2.0   # required for `from baseplate.frameworks.pyramid import BaseplateRequest` which calls `import pyramid.events`

--- a/tests/decider_tests.py
+++ b/tests/decider_tests.py
@@ -155,15 +155,14 @@ class TestDeciderGetVariant(unittest.TestCase):
         self.mock_span = mock.MagicMock(spec=ServerSpan)
         self.mock_span.context = None
         self.minimal_decider_context = DeciderContext(user_id=user_id)
-
-    def test_get_variant_expose_event_fields(self):
-        config = {
+        self.exp_base_config = {
             "exp_1": {
                 "id": 1,
                 "name": "exp_1",
                 "enabled": True,
                 "version": "2",
                 "type": "range_variant",
+                "emit_event": True,
                 "start_ts": 37173982,
                 "stop_ts": 2147483648,
                 "owner": "test_owner",
@@ -183,7 +182,8 @@ class TestDeciderGetVariant(unittest.TestCase):
             }
         }
 
-        with create_temp_config_file(config) as f:
+    def test_get_variant_expose_event_fields(self):
+        with create_temp_config_file(self.exp_base_config) as f:
             filewatcher = FileWatcher(path=f.name, parser=init_decider_parser, timeout=2, backoff=2)
             dc = DeciderContext(
                 user_id=user_id,
@@ -221,7 +221,7 @@ class TestDeciderGetVariant(unittest.TestCase):
             self.assertEqual(event_fields["event_type"], EventType.EXPOSE)
             self.assertNotEqual(event_fields["span"], None)
 
-            cfg = config["exp_1"]
+            cfg = self.exp_base_config["exp_1"]
             self.assertEqual(getattr(event_fields["experiment"], "id"), cfg["id"])
             self.assertEqual(getattr(event_fields["experiment"], "name"), cfg["name"])
             self.assertEqual(getattr(event_fields["experiment"], "owner"), cfg["owner"])
@@ -303,6 +303,121 @@ class TestDeciderGetVariant(unittest.TestCase):
             self.assertEqual(self.event_logger.log.call_count, 0)
             variant = decider.get_variant("anything")
             self.assertEqual(variant, None)
+
+    def test_get_variant_without_expose(self):
+        with create_temp_config_file(self.exp_base_config) as f:
+            filewatcher = FileWatcher(path=f.name, parser=init_decider_parser, timeout=2, backoff=2)
+            dc = DeciderContext(
+                user_id=user_id,
+                logged_in=is_logged_in,
+                country_code=country_code,
+                locale=locale_code,
+                origin_service=origin_service,
+                user_is_employee=True,
+                device_id=device_id,
+                auth_client_id=auth_client_id,
+                cookie_created_timestamp=cookie_created_timestamp,
+                extracted_fields=decider_field_extractor(request=None),
+            )
+
+            decider = Decider(
+                decider_context=dc,
+                config_watcher=filewatcher,
+                server_span=self.mock_span,
+                context_name="test",
+                event_logger=self.event_logger,
+            )
+
+            self.assertEqual(self.event_logger.log.call_count, 0)
+            variant = decider.get_variant_without_expose("exp_1")
+            self.assertEqual(variant, "variant_4")
+
+            # no exposures should be triggered
+            self.assertEqual(self.event_logger.log.call_count, 0)
+
+    def test_get_variant_without_expose_for_holdout_exposure(self):
+        parent_hg_config = {
+            "hg": {
+                "enabled": True,
+                "version": "5",
+                "type": "range_variant",
+                "emit_event": True,
+                "experiment": {
+                    "variants": [
+                        {
+                            "name": "holdout",
+                            "size": 1.0,
+                            "range_end": 1.0,
+                            "range_start": 0.0
+                        },
+                        {
+                            "name": "control_1",
+                            "size": 0.0,
+                            "range_end": 0.0,
+                            "range_start": 0.0
+                        }
+                    ],
+                    "experiment_version": 5,
+                    "shuffle_version": 0,
+                    "bucket_val": "user_id",
+                    "log_bucketing": False,
+                },
+                "start_ts": 0,
+                "stop_ts": 9668199193,
+                "id": 2,
+                "name": "hg",
+                "owner": "test",
+                "value": "range_variant"
+            }
+        }
+        self.exp_base_config["exp_1"].update({"parent_hg_name": "hg"})
+        self.exp_base_config.update(parent_hg_config)
+
+        with create_temp_config_file(self.exp_base_config) as f:
+            filewatcher = FileWatcher(path=f.name, parser=init_decider_parser, timeout=2, backoff=2)
+            dc = DeciderContext(
+                user_id=user_id,
+                logged_in=is_logged_in,
+                country_code=country_code,
+                locale=locale_code,
+                origin_service=origin_service,
+                user_is_employee=True,
+                device_id=device_id,
+                auth_client_id=auth_client_id,
+                cookie_created_timestamp=cookie_created_timestamp,
+                extracted_fields=decider_field_extractor(request=None),
+            )
+
+            decider = Decider(
+                decider_context=dc,
+                config_watcher=filewatcher,
+                server_span=self.mock_span,
+                context_name="test",
+                event_logger=self.event_logger,
+            )
+
+            self.assertEqual(self.event_logger.log.call_count, 0)
+            variant = decider.get_variant_without_expose("exp_1")
+            # exp_1 is part of Holdout, so None is returned
+            self.assertEqual(variant, None)
+
+            # exposure assertions
+            self.assertEqual(self.event_logger.log.call_count, 1)
+            event_fields = self.event_logger.log.call_args[1]
+
+            self.assertEqual(event_fields["variant"], "holdout")
+            self.assertEqual(event_fields["user_id"], user_id)
+            self.assertEqual(event_fields["logged_in"], is_logged_in)
+            self.assertEqual(event_fields["app_name"], app_name)
+            self.assertEqual(event_fields["cookie_created_timestamp"], cookie_created_timestamp)
+            self.assertEqual(event_fields["event_type"], EventType.EXPOSE)
+            self.assertNotEqual(event_fields["span"], None)
+
+            cfg = self.exp_base_config["hg"]
+            self.assertEqual(getattr(event_fields["experiment"], "id"), cfg["id"])
+            self.assertEqual(getattr(event_fields["experiment"], "name"), cfg["name"])
+            self.assertEqual(getattr(event_fields["experiment"], "owner"), cfg["owner"])
+            self.assertEqual(getattr(event_fields["experiment"], "version"), cfg["version"])
 
     # Todo: test exposure_kwargs
 

--- a/tests/decider_tests.py
+++ b/tests/decider_tests.py
@@ -181,25 +181,25 @@ class TestDeciderGetVariant(unittest.TestCase):
                 },
             }
         }
+        self.dc = DeciderContext(
+            user_id=user_id,
+            logged_in=is_logged_in,
+            country_code=country_code,
+            locale=locale_code,
+            origin_service=origin_service,
+            user_is_employee=True,
+            device_id=device_id,
+            auth_client_id=auth_client_id,
+            cookie_created_timestamp=cookie_created_timestamp,
+            extracted_fields=decider_field_extractor(request=None),
+        )
 
     def test_get_variant_expose_event_fields(self):
         with create_temp_config_file(self.exp_base_config) as f:
             filewatcher = FileWatcher(path=f.name, parser=init_decider_parser, timeout=2, backoff=2)
-            dc = DeciderContext(
-                user_id=user_id,
-                logged_in=is_logged_in,
-                country_code=country_code,
-                locale=locale_code,
-                origin_service=origin_service,
-                user_is_employee=True,
-                device_id=device_id,
-                auth_client_id=auth_client_id,
-                cookie_created_timestamp=cookie_created_timestamp,
-                extracted_fields=decider_field_extractor(request=None),
-            )
 
             decider = Decider(
-                decider_context=dc,
+                decider_context=self.dc,
                 config_watcher=filewatcher,
                 server_span=self.mock_span,
                 context_name="test",
@@ -307,21 +307,9 @@ class TestDeciderGetVariant(unittest.TestCase):
     def test_get_variant_without_expose(self):
         with create_temp_config_file(self.exp_base_config) as f:
             filewatcher = FileWatcher(path=f.name, parser=init_decider_parser, timeout=2, backoff=2)
-            dc = DeciderContext(
-                user_id=user_id,
-                logged_in=is_logged_in,
-                country_code=country_code,
-                locale=locale_code,
-                origin_service=origin_service,
-                user_is_employee=True,
-                device_id=device_id,
-                auth_client_id=auth_client_id,
-                cookie_created_timestamp=cookie_created_timestamp,
-                extracted_fields=decider_field_extractor(request=None),
-            )
 
             decider = Decider(
-                decider_context=dc,
+                decider_context=self.dc,
                 config_watcher=filewatcher,
                 server_span=self.mock_span,
                 context_name="test",
@@ -375,21 +363,9 @@ class TestDeciderGetVariant(unittest.TestCase):
 
         with create_temp_config_file(self.exp_base_config) as f:
             filewatcher = FileWatcher(path=f.name, parser=init_decider_parser, timeout=2, backoff=2)
-            dc = DeciderContext(
-                user_id=user_id,
-                logged_in=is_logged_in,
-                country_code=country_code,
-                locale=locale_code,
-                origin_service=origin_service,
-                user_is_employee=True,
-                device_id=device_id,
-                auth_client_id=auth_client_id,
-                cookie_created_timestamp=cookie_created_timestamp,
-                extracted_fields=decider_field_extractor(request=None),
-            )
 
             decider = Decider(
-                decider_context=dc,
+                decider_context=self.dc,
                 config_watcher=filewatcher,
                 server_span=self.mock_span,
                 context_name="test",


### PR DESCRIPTION
Implement `get_variant_without_expose()` to be used with `expose()` manually (will be implemented in follow-up pr).

Unit tests for `get_variant_without_expose()` called with:
1. A regular experiment
     - check that no exposure events were logged)
2. An experiment that's part of a Holdout Group at 100% bucketing
     - in which case we log a single exposure event for the HG with variant "holdout", while returning `None` to the user)