### PR TITLE
fix user_is_employee

### DIFF
--- a/reddit_decider/__init__.py
+++ b/reddit_decider/__init__.py
@@ -20,7 +20,7 @@ import rust_decider
 
 logger = logging.getLogger(__name__)
 
-EMPLOYEE_ROLES = ("employee", "contractor")
+EMPLOYEE_ROLES = ["employee", "contractor"]
 
 class EventType(Enum):
     EXPOSE = "expose"
@@ -487,12 +487,8 @@ class DeciderContextFactory(ContextFactory):
         self._request_field_extractor = request_field_extractor
 
     @classmethod
-    def is_employee(cls, edge_context: Any) -> bool:
-        return (
-            any([edge_context.user.has_role(role) for role in EMPLOYEE_ROLES])
-            if edge_context.user.is_logged_in
-            else False
-        )
+    def is_employee(cls, request_context: Any) -> bool:
+        return any(role in request_context.user_roles for role in EMPLOYEE_ROLES)
 
     def make_object_for_context(self, name: str, span: Span) -> Decider:
         decider = None
@@ -528,7 +524,7 @@ class DeciderContextFactory(ContextFactory):
                 country_code=ec.geolocation.country_code,
                 locale=ec.locale.locale_code,
                 origin_service=ec.origin_service.name,
-                user_is_employee=DeciderContextFactory.is_employee(ec),
+                user_is_employee=DeciderContextFactory.is_employee(request),
                 device_id=ec.device.id,
                 auth_client_id=auth_client_id,
                 cookie_created_timestamp=user_event_fields.get("cookie_created_timestamp"),

--- a/tests/decider_tests.py
+++ b/tests/decider_tests.py
@@ -97,6 +97,7 @@ class DeciderContextFactoryTests(unittest.TestCase):
         self.event_logger = mock.Mock(spec=DebugLogger)
         self.mock_span = mock.MagicMock(spec=ServerSpan)
         self.mock_span.context = mock.Mock()
+        self.mock_span.context.user_roles = ['employee']
         self.mock_span.context.edgecontext.user.event_fields = mock.Mock(
             return_value=event_fields
         )


### PR DESCRIPTION
not seeing `user_is_employee` populated in v2 events.

making this match what's in [graph-ql](https://github.snooguts.net/reddit/reddit-service-graphql/blob/9c7c1c0e75fd40bde952ffcd5785d5258be01a59/graphql-py/graphql_api/utils.py#L172-L173)