### PR TITLE
decider_context.to_event_dict()

### DIFF
--- a/tests/decider_tests.py
+++ b/tests/decider_tests.py
@@ -131,15 +131,32 @@ class DeciderContextFactoryTests(unittest.TestCase):
             decider_ctx_dict["cookie_created_timestamp"],
             self.mock_span.context.edgecontext.user.event_fields().get("cookie_created_timestamp"),
         )
+        self.assertEqual(decider_ctx_dict["app_name"], APP_NAME)
+        self.assertEqual(decider_ctx_dict["build_number"], BUILD_NUMBER)
+        self.assertEqual(decider_ctx_dict["canonical_url"], CANONICAL_URL)
+
+        decider_event_dict = decider_context.to_event_dict()
+        self.assertEqual(decider_event_dict["user_id"], USER_ID)
+        self.assertEqual(decider_event_dict["country_code"], COUNTRY_CODE)
+        self.assertEqual(decider_event_dict["geo_country_code"], COUNTRY_CODE)
+        self.assertEqual(decider_event_dict["user_is_employee"], True)
+        self.assertEqual(decider_event_dict["logged_in"], IS_LOGGED_IN)
+        self.assertEqual(decider_event_dict["user_logged_in"], IS_LOGGED_IN)
+        self.assertEqual(decider_event_dict["device_id"], DEVICE_ID)
+        self.assertEqual(decider_event_dict["platform_device_id"], DEVICE_ID)
+        self.assertEqual(decider_event_dict["locale"], LOCALE_CODE)
+        self.assertEqual(decider_event_dict["app_relevant_locale"], LOCALE_CODE)
+        self.assertEqual(decider_event_dict["origin_service"], ORIGIN_SERVICE)
+        self.assertEqual(decider_event_dict.get("auth_client_id"), None)
         self.assertEqual(
-            decider_ctx_dict["app_name"], APP_NAME
+            decider_event_dict["cookie_created_timestamp"],
+            self.mock_span.context.edgecontext.user.event_fields().get("cookie_created_timestamp"),
         )
-        self.assertEqual(
-            decider_ctx_dict["build_number"], BUILD_NUMBER
-        )
-        self.assertEqual(
-            decider_ctx_dict["canonical_url"], CANONICAL_URL
-        )
+        self.assertEqual(decider_event_dict["app_name"], APP_NAME)
+        self.assertEqual(decider_event_dict["build_number"], BUILD_NUMBER)
+        self.assertEqual(decider_event_dict["app_build_number"], BUILD_NUMBER)
+        self.assertEqual(decider_event_dict["canonical_url"], CANONICAL_URL)
+        self.assertEqual(decider_event_dict["request_canonical_url"], CANONICAL_URL)
 
 # Todo: test DeciderClient()
 # @mock.patch("reddit_decider.FileWatcher")


### PR DESCRIPTION
Some event fields require some massaging to be recognized by the schema.

Transforms:
- build_number -> [app_build_number](https://github.snooguts.net/reddit/data-schemas/blob/1031ebef2fad43cedb68024bb007cb22e2828b82/schemas/components/device.thrift#L192)
- canonical_url -> [request_canonical_url](https://github.snooguts.net/reddit/data-schemas/blob/60b0633ccafa910821c1dacf012d6508d88d4ce0/schemas/components/request.thrift#L81)
- locale -> [app_relevant_locale](https://github.snooguts.net/reddit/data-schemas/blob/1031ebef2fad43cedb68024bb007cb22e2828b82/schemas/components/device.thrift#L201)
- country_code -> [geo_country_code](https://github.snooguts.net/reddit/data-schemas/blob/733782eb28de98560c9c64beaaa04d6fe1330ef0/schemas/components/midas.thrift#L23)
- device_id -> [platform_device_id](https://github.snooguts.net/reddit/data-schemas/blob/1031ebef2fad43cedb68024bb007cb22e2828b82/schemas/components/device.thrift#L102)

New fields are appended and original fields are retained.