### PR TITLE
Append v2 event structs in to_event_dict()

### DIFF
--- a/tests/decider_tests.py
+++ b/tests/decider_tests.py
@@ -137,26 +137,34 @@ class DeciderContextFactoryTests(unittest.TestCase):
 
         decider_event_dict = decider_context.to_event_dict()
         self.assertEqual(decider_event_dict["user_id"], USER_ID)
+        self.assertEqual(decider_event_dict["user"]["id"], USER_ID)
         self.assertEqual(decider_event_dict["country_code"], COUNTRY_CODE)
-        self.assertEqual(decider_event_dict["geo_country_code"], COUNTRY_CODE)
+        self.assertEqual(decider_event_dict["geo"]["country_code"], COUNTRY_CODE)
         self.assertEqual(decider_event_dict["user_is_employee"], True)
+        self.assertEqual(decider_event_dict["user"]["is_employee"], True)
         self.assertEqual(decider_event_dict["logged_in"], IS_LOGGED_IN)
-        self.assertEqual(decider_event_dict["user_logged_in"], IS_LOGGED_IN)
+        self.assertEqual(decider_event_dict["user"]["logged_in"], IS_LOGGED_IN)
+
         self.assertEqual(decider_event_dict["device_id"], DEVICE_ID)
-        self.assertEqual(decider_event_dict["platform_device_id"], DEVICE_ID)
+        self.assertEqual(decider_event_dict["platform"]["device_id"], DEVICE_ID)
         self.assertEqual(decider_event_dict["locale"], LOCALE_CODE)
-        self.assertEqual(decider_event_dict["app_relevant_locale"], LOCALE_CODE)
+        self.assertEqual(decider_event_dict["app"]["relevant_locale"], LOCALE_CODE)
         self.assertEqual(decider_event_dict["origin_service"], ORIGIN_SERVICE)
         self.assertEqual(decider_event_dict.get("auth_client_id"), None)
         self.assertEqual(
             decider_event_dict["cookie_created_timestamp"],
             self.mock_span.context.edgecontext.user.event_fields().get("cookie_created_timestamp"),
         )
+        self.assertEqual(
+            decider_event_dict["user"]["cookie_created_timestamp"],
+            self.mock_span.context.edgecontext.user.event_fields().get("cookie_created_timestamp"),
+        )
         self.assertEqual(decider_event_dict["app_name"], APP_NAME)
+        self.assertEqual(decider_event_dict["app"]["name"], APP_NAME)
         self.assertEqual(decider_event_dict["build_number"], BUILD_NUMBER)
-        self.assertEqual(decider_event_dict["app_build_number"], BUILD_NUMBER)
+        self.assertEqual(decider_event_dict["app"]["build_number"], BUILD_NUMBER)
         self.assertEqual(decider_event_dict["canonical_url"], CANONICAL_URL)
-        self.assertEqual(decider_event_dict["request_canonical_url"], CANONICAL_URL)
+        self.assertEqual(decider_event_dict["request"]["canonical_url"], CANONICAL_URL)
 
 # Todo: test DeciderClient()
 # @mock.patch("reddit_decider.FileWatcher")


### PR DESCRIPTION
essentially mimic how event fields are grouped in the [event logger](https://github.snooguts.net/reddit/reddit-service-graphql/blob/3c5b239755b8ffb5770bfaa5ef5f5fd9e5e10635/graphql-py/graphql_api/events/utils.py#L205), so that future iterations of the logger don't have to do that.

Only adding new fields, so should be backwards compatible with existing event loggers.