### PR TITLE
Wrap event destructuring in except block, bump decider

### DIFF
--- a/reddit_decider/__init__.py
+++ b/reddit_decider/__init__.py
@@ -228,7 +228,12 @@ class Decider:
         event_context_fields.update(exposure_kwargs or {})
 
         for event in choice.events():
-            _event_type, exp_id, name, version, event_variant, _bucketing_value, bucket_val, start_ts, stop_ts, owner = event.split(":")
+            try:
+                _event_type, exp_id, name, version, event_variant, _bucketing_value, bucket_val, start_ts, stop_ts, owner = event.split("::::")
+            except ValueError:
+                logger.warning(f'Encountered error in event.split("::::") in get_variant(). event: {event}')
+                return variant
+
             experiment = ExperimentConfig(
                 id=int(exp_id),
                 name=name,
@@ -290,7 +295,12 @@ class Decider:
 
         # expose Holdout if the experiment is part of one
         for event in choice.events():
-            event_type, exp_id, name, version, event_variant, _bucketing_value, bucket_val, start_ts, stop_ts, owner = event.split(":")
+            try:
+                event_type, exp_id, name, version, event_variant, _bucketing_value, bucket_val, start_ts, stop_ts, owner = event.split("::::")
+            except ValueError:
+                logger.warning(f'Encountered error in event.split("::::") in get_variant_without_expose(). event: {event}')
+                return variant
+
             # event_type enum:
             #   0: regular bucketing
             #   1: override
@@ -424,7 +434,12 @@ class Decider:
         event_context_fields.update(exposure_kwargs or {})
 
         for event in choice.events():
-            _event_type, exp_id, name, version, event_variant, bucketing_value, bucket_val, start_ts, stop_ts, owner = event.split(":")
+            try:
+                _event_type, exp_id, name, version, event_variant, bucketing_value, bucket_val, start_ts, stop_ts, owner = event.split("::::")
+            except ValueError:
+                logger.warning(f'Encountered error in event.split("::::") in get_variant_for_identifier(). event: {event}')
+                return variant
+
             experiment = ExperimentConfig(
                 id=int(exp_id),
                 name=name,
@@ -510,7 +525,12 @@ class Decider:
 
         # expose Holdout if the experiment is part of one
         for event in choice.events():
-            event_type, exp_id, name, version, event_variant, bucketing_value, bucket_val, start_ts, stop_ts, owner = event.split(":")
+            try:
+                event_type, exp_id, name, version, event_variant, bucketing_value, bucket_val, start_ts, stop_ts, owner = event.split("::::")
+            except ValueError:
+                logger.warning(f'Encountered error in event.split("::::") in get_variant_for_identifier_without_expose(). event: {event}')
+                return variant
+
             # event_type enum:
             #   0: regular bucketing
             #   1: override

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 alabaster==0.7.12
 baseplate==2.0.0a1
 black==21.4b2
-reddit-decider==1.1.15
+reddit-decider==1.1.18
 flake8==3.9.1
 mypy==0.790
 pyramid==2.0   # required for `from baseplate.frameworks.pyramid import BaseplateRequest` which calls `import pyramid.events`


### PR DESCRIPTION
use `::::` instead of `:` colon delimiter.