### PR TITLE
Pass in identifier_type in get_variant_for_identifier...()

### DIFF
--- a/reddit_decider/__init__.py
+++ b/reddit_decider/__init__.py
@@ -379,40 +379,42 @@ class Decider:
     def get_variant_for_identifier(
         self,
         experiment_name: str,
-        identifier: str,
+        user_id: str = "",
+        device_id: str = None,
+        canonical_url: str = None,
         **exposure_kwargs: Optional[Dict[str, Any]]
     ) -> Optional[str]:
-        """Return a bucketing variant for `identifier`, if any, with auto-exposure.
-
-        The `identifier` param will be set on `DeciderClient` under:
-            `user_id`, `device_id`, & `canonical_url`,
-        so that regardless of what `bucketing_val` is set to in an experiment's config
-        (one of those 3), the passed in `identifier` param will be used in the
-        hashing string when bucketing.
+        """Return a bucketing variant for identifier, if any, with auto-exposure.
 
         Since calling `get_variant_for_identifier()` will fire an exposure event, it
         is best to call it when you are sure the user will be exposed to the experiment.
 
         :param experiment_name: Name of the experiment you want a variant for.
 
-        :param identifier: an arbitary string used to bucket the experiment by
-            being set on DeciderContext's 3 possible `bucket_val`'s
-            (`user_id`, `device_id`, & `canonical_url`).
+        :param user_id: sets user_id on DeciderContext for bucketing.
+
+        :param device_id: sets device_id on DeciderContext for bucketing.
+
+        :param canonical_url: sets canonical_url on DeciderContext for bucketing.
 
         :param exposure_kwargs:  Additional arguments that will be passed
             to events_logger under "inputs" key.
 
         :return: Variant name if a variant is assigned, None otherwise.
         """
+        if user_id is None and device_id is None and canonical_url is None:
+            logger.info("No identifiers passed into get_variant_for_identifier()")
+            return None
+
         decider = self._get_decider()
         if decider is None:
             logger.error("Encountered error in _get_decider()")
             return None
 
         identifier_context_fields = { **self._decider_context.to_dict(), **{
-            "user_id": identifier,
-            "device_id": identifier,
-            "canonical_url": identifier
+            "user_id": user_id,
+            "device_id": device_id,
+            "canonical_url": canonical_url
         }}
 
         ctx = rust_decider.make_ctx(identifier_context_fields)
@@ -468,15 +470,11 @@ class Decider:
     def get_variant_for_identifier_without_expose(
         self,
         experiment_name: str,
-        identifier: str,
+        user_id: str = "",
+        device_id: str = None,
+        canonical_url: str = None,
     ) -> Optional[str]:
         """Return a bucketing variant for `identifier`, if any, without emitting exposure event.
-
-        The `identifier` param will be set on `DeciderClient` under:
-            `user_id`, `device_id`, & `canonical_url`,
-        so that regardless of what `bucketing_val` is set to in an experiment's config
-        (one of those 3), the passed in `identifier` param will be used in the
-        hashing string when bucketing.
 
         The `expose()` function is available to be manually called afterward to emit
         exposure event.
@@ -489,21 +487,27 @@ class Decider:
 
         :param experiment_name: Name of the experiment you want a variant for.
 
-        :param identifier: an arbitary string used to bucket the experiment by
-            being set on DeciderContext's 3 possible `bucket_val`'s
-            (`user_id`, `device_id`, & `canonical_url`).
+        :param user_id: sets user_id on DeciderContext for bucketing.
+
+        :param device_id: sets device_id on DeciderContext for bucketing.
+
+        :param canonical_url: sets canonical_url on DeciderContext for bucketing.
 
         :return: Variant name if a variant is assigned, None otherwise.
         """
+        if user_id is None and device_id is None and canonical_url is None:
+            logger.info("No identifiers passed into get_variant_for_identifier()")
+            return None
+
         decider = self._get_decider()
         if decider is None:
             logger.error("Encountered error in _get_decider()")
             return None
 
         identifier_context_fields = { **self._decider_context.to_dict(), **{
-            "user_id": identifier,
-            "device_id": identifier,
-            "canonical_url": identifier
+            "user_id": user_id,
+            "device_id": device_id,
+            "canonical_url": canonical_url
         }}
 
         ctx = rust_decider.make_ctx(identifier_context_fields)

--- a/reddit_decider/__init__.py
+++ b/reddit_decider/__init__.py
@@ -2,7 +2,8 @@ import logging
 
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any, Callable, Dict, IO, Literal, Optional
+from typing import Any, Callable, Dict, IO, Optional
+from typing_extensions import Literal
 
 from baseplate import RequestContext
 from baseplate import Span

--- a/requirements-transitive.txt
+++ b/requirements-transitive.txt
@@ -42,7 +42,7 @@ sphinxcontrib-serializinghtml==1.1.4
 thrift==0.13.0
 toml==0.10.2
 typed-ast==1.4.3
-typing-extensions==4.2.0
+typing-extensions==3.7.4.3
 urllib3==1.26.2
 zope.event==4.5.0
 zope.interface==5.2.0

--- a/requirements-transitive.txt
+++ b/requirements-transitive.txt
@@ -42,7 +42,7 @@ sphinxcontrib-serializinghtml==1.1.4
 thrift==0.13.0
 toml==0.10.2
 typed-ast==1.4.3
-typing-extensions==3.7.4.3
+typing-extensions==4.2.0
 urllib3==1.26.2
 zope.event==4.5.0
 zope.interface==5.2.0

--- a/tests/decider_tests.py
+++ b/tests/decider_tests.py
@@ -475,7 +475,7 @@ class TestDeciderGetVariantAndExpose(unittest.TestCase):
             )
 
             self.assertEqual(self.event_logger.log.call_count, 0)
-            variant = decider.get_variant_for_identifier(experiment_name="exp_1", identifier=identifier)
+            variant = decider.get_variant_for_identifier(experiment_name="exp_1", user_id=identifier)
             self.assertEqual(variant, "variant_4")
 
             # exposure assertions
@@ -503,7 +503,7 @@ class TestDeciderGetVariantAndExpose(unittest.TestCase):
             )
 
             self.assertEqual(self.event_logger.log.call_count, 0)
-            variant = decider.get_variant_for_identifier(experiment_name="exp_1", identifier=identifier)
+            variant = decider.get_variant_for_identifier(experiment_name="exp_1", canonical_url=identifier)
             self.assertEqual(variant, "variant_3")
 
             # exposure assertions
@@ -531,7 +531,7 @@ class TestDeciderGetVariantAndExpose(unittest.TestCase):
             )
 
             self.assertEqual(self.event_logger.log.call_count, 0)
-            variant = decider.get_variant_for_identifier(experiment_name="exp_1", identifier=identifier)
+            variant = decider.get_variant_for_identifier(experiment_name="exp_1", device_id=identifier)
             self.assertEqual(variant, "variant_3")
 
             # exposure assertions
@@ -541,6 +541,30 @@ class TestDeciderGetVariantAndExpose(unittest.TestCase):
 
             # `identifier` passed to correct event field of experiment's `bucket_val` config
             self.assertEqual(event_fields["device_id"], identifier)
+
+    def test_get_variant_for_identifier_wrong_bucket_val(self):
+        identifier = USER_ID
+        bucket_val = "device_id"
+        self.exp_base_config["exp_1"]["experiment"].update({"bucket_val": bucket_val})
+
+        with create_temp_config_file(self.exp_base_config) as f:
+            filewatcher = FileWatcher(path=f.name, parser=init_decider_parser, timeout=2, backoff=2)
+
+            decider = Decider(
+                decider_context=self.dc,
+                config_watcher=filewatcher,
+                server_span=self.mock_span,
+                context_name="test",
+                event_logger=self.event_logger,
+            )
+
+            self.assertEqual(self.event_logger.log.call_count, 0)
+            # pass device_id identifier to wrong kwarg, `canonical_url`
+            variant = decider.get_variant_for_identifier(experiment_name="exp_1", canonical_url=identifier)
+            self.assertEqual(variant, None)
+
+            # exposure not emitted since `bucket_val` doesn't match `user_id` kwargs in `get_variant_for_identifier()``
+            self.assertEqual(self.event_logger.log.call_count, 0)
 
     def test_expose(self):
         with create_temp_config_file(self.exp_base_config) as f:
@@ -576,7 +600,7 @@ class TestDeciderGetVariantAndExpose(unittest.TestCase):
             )
 
             self.assertEqual(self.event_logger.log.call_count, 0)
-            variant = decider.get_variant_for_identifier_without_expose(experiment_name="exp_1", identifier=USER_ID)
+            variant = decider.get_variant_for_identifier_without_expose(experiment_name="exp_1", user_id=USER_ID)
             self.assertEqual(variant, "variant_4")
 
             # no exposures should be triggered
@@ -598,7 +622,7 @@ class TestDeciderGetVariantAndExpose(unittest.TestCase):
             )
 
             self.assertEqual(self.event_logger.log.call_count, 0)
-            variant = decider.get_variant_for_identifier_without_expose(experiment_name="exp_1", identifier=USER_ID)
+            variant = decider.get_variant_for_identifier_without_expose(experiment_name="exp_1", user_id=USER_ID)
             # user is part of Holdout (100% bucketing), so `None` is returned
             self.assertEqual(variant, None)
 
@@ -608,6 +632,33 @@ class TestDeciderGetVariantAndExpose(unittest.TestCase):
 
             # `variant == None` for holdout but event will fire with `variant == 'holdout'` for analysis
             self.assert_exposure_event_fields(experiment_name="hg", variant='holdout', event_fields=event_fields)
+
+    def test_get_variant_for_identifier_without_expose_for_holdout_exposure_wrong_bucket_val(self):
+        identifier = DEVICE_ID
+        bucket_val = "device_id"
+        self.exp_base_config["exp_1"]["experiment"].update({"bucket_val": bucket_val})
+
+        self.exp_base_config["exp_1"].update({"parent_hg_name": "hg"})
+        self.parent_hg_config["hg"]["experiment"].update({"bucket_val": bucket_val})
+        self.exp_base_config.update(self.parent_hg_config)
+
+        with create_temp_config_file(self.exp_base_config) as f:
+            filewatcher = FileWatcher(path=f.name, parser=init_decider_parser, timeout=2, backoff=2)
+
+            decider = Decider(
+                decider_context=self.dc,
+                config_watcher=filewatcher,
+                server_span=self.mock_span,
+                context_name="test",
+                event_logger=self.event_logger,
+            )
+
+            self.assertEqual(self.event_logger.log.call_count, 0)
+            # pass device_id identifier to wrong kwarg, `canonical_url`
+            variant = decider.get_variant_for_identifier_without_expose(experiment_name="exp_1", canonical_url=USER_ID)
+            # `None` is returned since identifier type in kwarg doesn't match bucket_val in experiment-config json
+            self.assertEqual(variant, None)
+            self.assertEqual(self.event_logger.log.call_count, 0)
 
     def test_get_variant_for_identifier_without_expose_canonical_url(self):
         identifier = CANONICAL_URL
@@ -626,7 +677,7 @@ class TestDeciderGetVariantAndExpose(unittest.TestCase):
             )
 
             self.assertEqual(self.event_logger.log.call_count, 0)
-            variant = decider.get_variant_for_identifier_without_expose(experiment_name="exp_1", identifier=identifier)
+            variant = decider.get_variant_for_identifier_without_expose(experiment_name="exp_1", canonical_url=identifier)
             self.assertEqual(variant, "variant_3")
 
             # no exposures should be triggered
@@ -649,7 +700,7 @@ class TestDeciderGetVariantAndExpose(unittest.TestCase):
             )
 
             self.assertEqual(self.event_logger.log.call_count, 0)
-            variant = decider.get_variant_for_identifier_without_expose(experiment_name="exp_1", identifier=identifier)
+            variant = decider.get_variant_for_identifier_without_expose(experiment_name="exp_1", device_id=identifier)
             self.assertEqual(variant, "variant_3")
 
             # no exposures should be triggered

--- a/tests/decider_tests.py
+++ b/tests/decider_tests.py
@@ -475,7 +475,7 @@ class TestDeciderGetVariantAndExpose(unittest.TestCase):
             )
 
             self.assertEqual(self.event_logger.log.call_count, 0)
-            variant = decider.get_variant_for_identifier(experiment_name="exp_1", user_id=identifier)
+            variant = decider.get_variant_for_identifier(experiment_name="exp_1", identifier=identifier, identifier_type="user_id")
             self.assertEqual(variant, "variant_4")
 
             # exposure assertions
@@ -503,7 +503,7 @@ class TestDeciderGetVariantAndExpose(unittest.TestCase):
             )
 
             self.assertEqual(self.event_logger.log.call_count, 0)
-            variant = decider.get_variant_for_identifier(experiment_name="exp_1", canonical_url=identifier)
+            variant = decider.get_variant_for_identifier(experiment_name="exp_1", identifier=identifier, identifier_type="canonical_url")
             self.assertEqual(variant, "variant_3")
 
             # exposure assertions
@@ -531,7 +531,7 @@ class TestDeciderGetVariantAndExpose(unittest.TestCase):
             )
 
             self.assertEqual(self.event_logger.log.call_count, 0)
-            variant = decider.get_variant_for_identifier(experiment_name="exp_1", device_id=identifier)
+            variant = decider.get_variant_for_identifier(experiment_name="exp_1", identifier=identifier, identifier_type="device_id")
             self.assertEqual(variant, "variant_3")
 
             # exposure assertions
@@ -551,7 +551,7 @@ class TestDeciderGetVariantAndExpose(unittest.TestCase):
             filewatcher = FileWatcher(path=f.name, parser=init_decider_parser, timeout=2, backoff=2)
 
             decider = Decider(
-                decider_context=self.dc,
+                decider_context=self.minimal_decider_context,
                 config_watcher=filewatcher,
                 server_span=self.mock_span,
                 context_name="test",
@@ -559,11 +559,11 @@ class TestDeciderGetVariantAndExpose(unittest.TestCase):
             )
 
             self.assertEqual(self.event_logger.log.call_count, 0)
-            # pass device_id identifier to wrong kwarg, `canonical_url`
-            variant = decider.get_variant_for_identifier(experiment_name="exp_1", canonical_url=identifier)
+            # `identifier_type="canonical_url"`, which doesn't match `bucket_val` of `device_id`
+            variant = decider.get_variant_for_identifier(experiment_name="exp_1", identifier=identifier, identifier_type="canonical_url")
+            # `None` is returned since `identifier_type` doesn't match `bucket_val` in experiment-config json
             self.assertEqual(variant, None)
-
-            # exposure not emitted since `bucket_val` doesn't match `user_id` kwargs in `get_variant_for_identifier()``
+            # exposure isn't emitted either
             self.assertEqual(self.event_logger.log.call_count, 0)
 
     def test_expose(self):
@@ -592,7 +592,7 @@ class TestDeciderGetVariantAndExpose(unittest.TestCase):
             filewatcher = FileWatcher(path=f.name, parser=init_decider_parser, timeout=2, backoff=2)
 
             decider = Decider(
-                decider_context=self.dc,
+                decider_context=self.minimal_decider_context,
                 config_watcher=filewatcher,
                 server_span=self.mock_span,
                 context_name="test",
@@ -600,7 +600,7 @@ class TestDeciderGetVariantAndExpose(unittest.TestCase):
             )
 
             self.assertEqual(self.event_logger.log.call_count, 0)
-            variant = decider.get_variant_for_identifier_without_expose(experiment_name="exp_1", user_id=USER_ID)
+            variant = decider.get_variant_for_identifier_without_expose(experiment_name="exp_1", identifier=USER_ID, identifier_type="user_id")
             self.assertEqual(variant, "variant_4")
 
             # no exposures should be triggered
@@ -622,7 +622,7 @@ class TestDeciderGetVariantAndExpose(unittest.TestCase):
             )
 
             self.assertEqual(self.event_logger.log.call_count, 0)
-            variant = decider.get_variant_for_identifier_without_expose(experiment_name="exp_1", user_id=USER_ID)
+            variant = decider.get_variant_for_identifier_without_expose(experiment_name="exp_1", identifier=USER_ID, identifier_type="user_id")
             # user is part of Holdout (100% bucketing), so `None` is returned
             self.assertEqual(variant, None)
 
@@ -646,7 +646,7 @@ class TestDeciderGetVariantAndExpose(unittest.TestCase):
             filewatcher = FileWatcher(path=f.name, parser=init_decider_parser, timeout=2, backoff=2)
 
             decider = Decider(
-                decider_context=self.dc,
+                decider_context=self.minimal_decider_context,
                 config_watcher=filewatcher,
                 server_span=self.mock_span,
                 context_name="test",
@@ -654,9 +654,9 @@ class TestDeciderGetVariantAndExpose(unittest.TestCase):
             )
 
             self.assertEqual(self.event_logger.log.call_count, 0)
-            # pass device_id identifier to wrong kwarg, `canonical_url`
-            variant = decider.get_variant_for_identifier_without_expose(experiment_name="exp_1", canonical_url=USER_ID)
-            # `None` is returned since identifier type in kwarg doesn't match bucket_val in experiment-config json
+            # `identifier_type="canonical_url"`, which doesn't match `bucket_val` of `device_id`
+            variant = decider.get_variant_for_identifier_without_expose(experiment_name="exp_1", identifier=identifier, identifier_type="canonical_url")
+            # `None` is returned since `identifier_type` doesn't match `bucket_val` in experiment-config json
             self.assertEqual(variant, None)
             self.assertEqual(self.event_logger.log.call_count, 0)
 
@@ -669,7 +669,7 @@ class TestDeciderGetVariantAndExpose(unittest.TestCase):
             filewatcher = FileWatcher(path=f.name, parser=init_decider_parser, timeout=2, backoff=2)
 
             decider = Decider(
-                decider_context=self.dc,
+                decider_context=self.minimal_decider_context,
                 config_watcher=filewatcher,
                 server_span=self.mock_span,
                 context_name="test",
@@ -677,7 +677,7 @@ class TestDeciderGetVariantAndExpose(unittest.TestCase):
             )
 
             self.assertEqual(self.event_logger.log.call_count, 0)
-            variant = decider.get_variant_for_identifier_without_expose(experiment_name="exp_1", canonical_url=identifier)
+            variant = decider.get_variant_for_identifier_without_expose(experiment_name="exp_1", identifier=identifier, identifier_type="canonical_url")
             self.assertEqual(variant, "variant_3")
 
             # no exposures should be triggered
@@ -692,7 +692,7 @@ class TestDeciderGetVariantAndExpose(unittest.TestCase):
             filewatcher = FileWatcher(path=f.name, parser=init_decider_parser, timeout=2, backoff=2)
 
             decider = Decider(
-                decider_context=self.dc,
+                decider_context=self.minimal_decider_context,
                 config_watcher=filewatcher,
                 server_span=self.mock_span,
                 context_name="test",
@@ -700,7 +700,7 @@ class TestDeciderGetVariantAndExpose(unittest.TestCase):
             )
 
             self.assertEqual(self.event_logger.log.call_count, 0)
-            variant = decider.get_variant_for_identifier_without_expose(experiment_name="exp_1", device_id=identifier)
+            variant = decider.get_variant_for_identifier_without_expose(experiment_name="exp_1", identifier=identifier, identifier_type="device_id")
             self.assertEqual(variant, "variant_3")
 
             # no exposures should be triggered


### PR DESCRIPTION
We produce variant result when calling `get_variant_for_identifier()` based on 'canonical url', even for the experiments targeting `bucket_val: user_id`, which should return `None`.

Now, we specify the identifier type as a kwarg to be used in `DeciderContext` and return `None` if there's a mismatch.

However, this won't work for `bucket_val: user_id` experiments if `get_variant_for_identifier()` is called with incorrect kwarg, e.g. `get_variant_for_identifier("exp_name", device_id: "asdf")` because I have to set param `user_id: str = ""` to default to empty string, because rust decider requires a `user_id` to initiate.