### PR TITLE
get_all_variants_without_expose() & get_all_variants_for_identifier_without_expose()

### DIFF
--- a/reddit_decider/__init__.py
+++ b/reddit_decider/__init__.py
@@ -23,8 +23,10 @@ logger = logging.getLogger(__name__)
 
 EMPLOYEE_ROLES = ("employee", "contractor")
 
+
 class EventType(Enum):
     EXPOSE = "expose"
+
 
 @dataclass
 class ExperimentConfig:
@@ -35,6 +37,7 @@ class ExperimentConfig:
     start_ts: int
     stop_ts: int
     owner: str
+
 
 class DeciderContext:
     """DeciderContext() is used to contain all fields necessary for
@@ -132,8 +135,10 @@ class DeciderContext:
             **ef,
         }
 
+
 def init_decider_parser(file: IO) -> Any:
     return rust_decider.init("darkmode overrides targeting holdout mutex_group fractional_availability value", file.name)
+
 
 def validate_decider(decider: Optional[Any]) -> None:
     if decider is None:
@@ -449,7 +454,7 @@ class Decider:
             )
 
             # expose the `bucket_val` used in the experiment's config, not `identifier_context_fields`
-            event_ctx_fields = { **event_context_fields, **{bucket_val: bucketing_value}}
+            event_ctx_fields = {**event_context_fields, **{bucket_val: bucketing_value}}
 
             self._event_logger.log(
                 experiment=experiment,
@@ -461,7 +466,6 @@ class Decider:
             )
 
         return variant
-
 
     def get_variant_for_identifier_without_expose(
         self,
@@ -542,7 +546,7 @@ class Decider:
                 )
 
                 # expose the `bucket_val` used in the experiment's config, not `identifier_context_fields`
-                event_ctx_fields = { **event_context_fields, **{bucket_val: bucketing_value}}
+                event_ctx_fields = {**event_context_fields, **{bucket_val: bucketing_value}}
 
                 self._event_logger.log(
                     experiment=experiment,
@@ -554,6 +558,178 @@ class Decider:
                 )
 
         return variant
+
+    def get_all_variants_without_expose(self) -> Dict[str, Optional[str]]:
+        """Return a dict of experiment name strings as keys and
+            variant names as the values (if a variant is assigned,
+            and None otherwise). All available experiments get bucketed.
+            Exposure events are not emitted.
+
+        The `expose()` function is available to be manually called afterward to emit
+        exposure event.
+
+        However, experiments in Holdout Groups will still send an exposure for
+        the holdout parent experiment, since it is not possible to
+        manually expose the holdout later (because after exiting this function,
+        it's impossible to know if a returned `None` or `"control_1"` string
+        came from the holdout group or its child experiment).
+
+        :return: dict of experiment name strings as keys and
+            variant names, or `None`, as the values
+        """
+        decider = self._get_decider()
+        if decider is None:
+            logger.error("Encountered error in _get_decider()")
+            return None
+
+        context_fields = self._decider_context.to_dict()
+        ctx = rust_decider.make_ctx(context_fields)
+        ctx_err = ctx.err()
+        if ctx_err is not None:
+            logger.info(f"Encountered error in rust_decider.make_ctx(): {ctx_err}")
+            return {}
+
+        all_choices = decider.choose_all(ctx)
+        parsed_choices = {}
+
+        event_context_fields = self._decider_context.to_event_dict()
+
+        for exp_name, choice in all_choices.items():
+            choice_error = choice.err()
+            if choice_error:
+                logger.info(f"Encountered error for experiment: {exp_name} in decider.choose_all(): {choice_error}")
+                parsed_choices[exp_name] = None
+            else:
+                parsed_choices[exp_name] = choice.decision()
+
+                # expose Holdout if the experiment is part of one
+                for event in choice.events():
+                    try:
+                        event_type, exp_id, name, version, event_variant, bucketing_value, bucket_val, start_ts, stop_ts, owner = event.split("::::")
+                    except ValueError:
+                        logger.warning(f'Encountered error in event.split("::::") for {exp_name} in get_all_variants_without_expose(). event: {event}')
+                        continue
+
+                    # event_type enum:
+                    #   0: regular bucketing
+                    #   1: override
+                    #   2: holdout
+                    if event_type == "2":
+                        experiment = ExperimentConfig(
+                            id=int(exp_id),
+                            name=name,
+                            version=version,
+                            bucket_val=bucket_val,
+                            start_ts=start_ts,
+                            stop_ts=stop_ts,
+                            owner=owner
+                        )
+
+                        self._event_logger.log(
+                            experiment=experiment,
+                            variant=event_variant,
+                            span=self._span,
+                            event_type=EventType.EXPOSE,
+                            inputs=event_context_fields.copy(),
+                            **event_context_fields.copy(),
+                        )
+
+        return parsed_choices
+
+    def get_all_variants_for_identifier_without_expose(
+        self,
+        identifier: str,
+        identifier_type: Literal["user_id", "device_id", "canonical_url"]
+    ) -> Optional[str]:
+        """Return a dict of experiment name strings as keys and
+            variant names as the values (if a variant is assigned,
+            and None otherwise) for `identifier`. Exposure events are not emitted.
+            All available experiments get bucketed.
+
+        The `expose()` function is available to be manually called afterward to emit
+        exposure event.
+
+        However, experiments in Holdout Groups will still send an exposure for
+        the holdout parent experiment, since it is not possible to
+        manually expose the holdout later (because after exiting this function,
+        it's impossible to know if a returned `None` or `"control_1"` string
+        came from the holdout group or its child experiment).
+
+        :param identifier: an arbitary string used to bucket the experiment by
+            being set on `DeciderContext`'s `identifier_type` field.
+
+        :param identifier_type: (one of ["user_id", "device_id", "canonical_url"])
+            Sets `{identifier_type: identifier}` on DeciderContext and
+            should match an experiment's `bucket_val` to get a variant.
+
+        :return: dict of experiment name strings as keys and
+            variant names, or `None`, as the values
+        """
+        decider = self._get_decider()
+        if decider is None:
+            logger.error("Encountered error in _get_decider()")
+            return None
+
+        identifier_context_fields = {
+            **self._decider_context.to_dict(),
+            **{identifier_type: identifier}
+        }
+
+        ctx = rust_decider.make_ctx(identifier_context_fields)
+        ctx_err = ctx.err()
+        if ctx_err is not None:
+            logger.info(f"Encountered error in rust_decider.make_ctx(): {ctx_err}")
+            return None
+
+        all_choices = decider.choose_all(ctx)
+        parsed_choices = {}
+
+        event_context_fields = self._decider_context.to_event_dict()
+
+        for exp_name, choice in all_choices.items():
+            choice_error = choice.err()
+            if choice_error:
+                logger.info(f"Encountered error for experiment: {exp_name} in decider.choose_all(): {choice_error}")
+                parsed_choices[exp_name] = None
+            else:
+                parsed_choices[exp_name] = choice.decision()
+
+                # expose Holdout if the experiment is part of one
+                for event in choice.events():
+                    try:
+                        event_type, exp_id, name, version, event_variant, bucketing_value, bucket_val, start_ts, stop_ts, owner = event.split("::::")
+                    except ValueError:
+                        logger.warning(f'Encountered error in event.split("::::") for {exp_name} in get_all_variants_without_expose(). event: {event}')
+                        continue
+
+                    # event_type enum:
+                    #   0: regular bucketing
+                    #   1: override
+                    #   2: holdout
+                    if event_type == "2":
+                        experiment = ExperimentConfig(
+                            id=int(exp_id),
+                            name=name,
+                            version=version,
+                            bucket_val=bucket_val,
+                            start_ts=start_ts,
+                            stop_ts=stop_ts,
+                            owner=owner
+                        )
+
+                        # expose the `bucket_val` used in the experiment's config, not `identifier_context_fields`
+                        event_ctx_fields = {**event_context_fields, **{bucket_val: bucketing_value}}
+
+                        self._event_logger.log(
+                            experiment=experiment,
+                            variant=event_variant,
+                            span=self._span,
+                            event_type=EventType.EXPOSE,
+                            inputs=event_ctx_fields.copy(),
+                            **event_ctx_fields.copy(),
+                        )
+
+        return parsed_choices
 
     def _get_dynamic_config_value(
         self,
@@ -567,7 +743,6 @@ class Decider:
         if ctx_err is not None:
             logger.info(f"Encountered error in rust_decider.make_ctx(): {ctx_err}")
             return None
-
 
         res = decider_func(feature_name, ctx)
         if res is None:

--- a/reddit_decider/__init__.py
+++ b/reddit_decider/__init__.py
@@ -453,7 +453,7 @@ class Decider:
                 owner=owner
             )
 
-            # expose the `bucket_val` used in the experiment's config, not `identifier_context_fields`
+            # expose the `bucket_val` used in the experiment's config
             event_ctx_fields = {**event_context_fields, **{bucket_val: bucketing_value}}
 
             self._event_logger.log(
@@ -545,7 +545,7 @@ class Decider:
                     owner=owner
                 )
 
-                # expose the `bucket_val` used in the experiment's config, not `identifier_context_fields`
+                # expose the `bucket_val` used in the experiment's config
                 event_ctx_fields = {**event_context_fields, **{bucket_val: bucketing_value}}
 
                 self._event_logger.log(
@@ -561,8 +561,8 @@ class Decider:
 
     def get_all_variants_without_expose(self) -> Dict[str, Optional[str]]:
         """Return a dict of experiment name strings as keys and
-            variant names as the values (if a variant is assigned,
-            and None otherwise). All available experiments get bucketed.
+            variant names as the values (if a variant is assigned
+            or None otherwise). All available experiments get bucketed.
             Exposure events are not emitted.
 
         The `expose()` function is available to be manually called afterward to emit
@@ -575,7 +575,7 @@ class Decider:
         came from the holdout group or its child experiment).
 
         :return: dict of experiment name strings as keys and
-            variant names, or `None`, as the values
+            variant names (or `None`) as the values
         """
         decider = self._get_decider()
         if decider is None:
@@ -642,8 +642,8 @@ class Decider:
         identifier_type: Literal["user_id", "device_id", "canonical_url"]
     ) -> Optional[str]:
         """Return a dict of experiment name strings as keys and
-            variant names as the values (if a variant is assigned,
-            and None otherwise) for `identifier`. Exposure events are not emitted.
+            variant names as the values (if a variant is assigned
+            or None otherwise) for `identifier`. Exposure events are not emitted.
             All available experiments get bucketed.
 
         The `expose()` function is available to be manually called afterward to emit
@@ -663,7 +663,7 @@ class Decider:
             should match an experiment's `bucket_val` to get a variant.
 
         :return: dict of experiment name strings as keys and
-            variant names, or `None`, as the values
+            variant names (or `None`) as the values
         """
         decider = self._get_decider()
         if decider is None:
@@ -679,7 +679,7 @@ class Decider:
         ctx_err = ctx.err()
         if ctx_err is not None:
             logger.info(f"Encountered error in rust_decider.make_ctx(): {ctx_err}")
-            return None
+            return {}
 
         all_choices = decider.choose_all(ctx)
         parsed_choices = {}
@@ -717,7 +717,7 @@ class Decider:
                             owner=owner
                         )
 
-                        # expose the `bucket_val` used in the experiment's config, not `identifier_context_fields`
+                        # expose the `bucket_val` used in the experiment's config
                         event_ctx_fields = {**event_context_fields, **{bucket_val: bucketing_value}}
 
                         self._event_logger.log(

--- a/reddit_decider/__init__.py
+++ b/reddit_decider/__init__.py
@@ -580,7 +580,7 @@ class Decider:
         decider = self._get_decider()
         if decider is None:
             logger.error("Encountered error in _get_decider()")
-            return None
+            return {}
 
         context_fields = self._decider_context.to_dict()
         ctx = rust_decider.make_ctx(context_fields)
@@ -668,7 +668,7 @@ class Decider:
         decider = self._get_decider()
         if decider is None:
             logger.error("Encountered error in _get_decider()")
-            return None
+            return {}
 
         identifier_context_fields = {
             **self._decider_context.to_dict(),

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 alabaster==0.7.12
 baseplate==2.0.0a1
 black==21.4b2
-reddit-decider==1.1.18
+reddit-decider==1.1.19
 flake8==3.9.1
 mypy==0.790
 pyramid==2.0   # required for `from baseplate.frameworks.pyramid import BaseplateRequest` which calls `import pyramid.events`

--- a/tests/decider_tests.py
+++ b/tests/decider_tests.py
@@ -655,6 +655,9 @@ class TestDeciderGetVariantAndExpose(unittest.TestCase):
             self.assert_exposure_event_fields(experiment_name="exp_1", variant=variant, event_fields=event_fields)
 
     def test_get_variant_for_identifier_without_expose_user_id(self):
+        identifier = USER_ID
+        bucket_val = "user_id"
+
         with create_temp_config_file(self.exp_base_config) as f:
             filewatcher = FileWatcher(path=f.name, parser=init_decider_parser, timeout=2, backoff=2)
 
@@ -667,13 +670,16 @@ class TestDeciderGetVariantAndExpose(unittest.TestCase):
             )
 
             self.assertEqual(self.event_logger.log.call_count, 0)
-            variant = decider.get_variant_for_identifier_without_expose(experiment_name="exp_1", identifier=USER_ID, identifier_type="user_id")
+            variant = decider.get_variant_for_identifier_without_expose(experiment_name="exp_1", identifier=identifier, identifier_type=bucket_val)
             self.assertEqual(variant, "variant_4")
 
             # no exposures should be triggered
             self.assertEqual(self.event_logger.log.call_count, 0)
 
     def test_get_variant_for_identifier_without_expose_user_id_for_holdout_exposure(self):
+        identifier = USER_ID
+        bucket_val = "user_id"
+
         self.exp_base_config["exp_1"].update({"parent_hg_name": "hg"})
         self.exp_base_config.update(self.parent_hg_config)
 
@@ -689,7 +695,7 @@ class TestDeciderGetVariantAndExpose(unittest.TestCase):
             )
 
             self.assertEqual(self.event_logger.log.call_count, 0)
-            variant = decider.get_variant_for_identifier_without_expose(experiment_name="exp_1", identifier=USER_ID, identifier_type="user_id")
+            variant = decider.get_variant_for_identifier_without_expose(experiment_name="exp_1", identifier=identifier, identifier_type=bucket_val)
             # user is part of Holdout (100% bucketing), so `None` is returned
             self.assertEqual(variant, None)
 
@@ -834,6 +840,9 @@ class TestDeciderGetVariantAndExpose(unittest.TestCase):
             self.assert_exposure_event_fields(experiment_name="hg", variant='holdout', event_fields=event_fields)
 
     def test_get_all_variants_for_identifier_without_expose_user_id(self):
+        identifier = USER_ID
+        bucket_val = "user_id"
+
         # add 2 more experiments
         self.exp_base_config.update(self.additional_two_exp)
 
@@ -849,7 +858,7 @@ class TestDeciderGetVariantAndExpose(unittest.TestCase):
             )
 
             self.assertEqual(self.event_logger.log.call_count, 0)
-            variant_dict = decider.get_all_variants_for_identifier_without_expose(identifier=USER_ID, identifier_type="user_id")
+            variant_dict = decider.get_all_variants_for_identifier_without_expose(identifier=identifier, identifier_type=bucket_val)
 
             self.assertEqual(len(variant_dict), len(self.exp_base_config))
             self.assertEqual(variant_dict["exp_1"], "variant_4")
@@ -860,6 +869,9 @@ class TestDeciderGetVariantAndExpose(unittest.TestCase):
             self.assertEqual(self.event_logger.log.call_count, 0)
 
     def test_get_all_variants_for_identifier_without_expose_user_id_wrong_bucket(self):
+        identifier = USER_ID
+        bucket_val = "user_id"
+
         # add 2 more experiments
         self.exp_base_config.update(self.additional_two_exp)
         # alter `bucket_val` on exp_1 to induce err() due to `identifier_type` mismatch
@@ -878,7 +890,7 @@ class TestDeciderGetVariantAndExpose(unittest.TestCase):
 
             self.assertEqual(self.event_logger.log.call_count, 0)
             with self.assertLogs() as captured:
-                variant_dict = decider.get_all_variants_for_identifier_without_expose(identifier=USER_ID, identifier_type="user_id")
+                variant_dict = decider.get_all_variants_for_identifier_without_expose(identifier=identifier, identifier_type=bucket_val)
 
                 assert(any('Encountered error for experiment: exp_1 in decider.choose_all(): Missing "device_id" in context for bucket_val = "device_id"' in x.getMessage() for x in captured.records))
 
@@ -891,6 +903,9 @@ class TestDeciderGetVariantAndExpose(unittest.TestCase):
                 self.assertEqual(self.event_logger.log.call_count, 0)
 
     def test_get_all_variants_for_identifier_without_expose_user_id_with_hg(self):
+        identifier = USER_ID
+        bucket_val = "user_id"
+
         # include an HG to test event still emitted for bulk call
         self.exp_base_config["exp_1"].update({"parent_hg_name": "hg"})
         self.exp_base_config.update(self.parent_hg_config)
@@ -910,7 +925,7 @@ class TestDeciderGetVariantAndExpose(unittest.TestCase):
             )
 
             self.assertEqual(self.event_logger.log.call_count, 0)
-            variant_dict = decider.get_all_variants_for_identifier_without_expose(identifier=USER_ID, identifier_type="user_id")
+            variant_dict = decider.get_all_variants_for_identifier_without_expose(identifier=identifier, identifier_type=bucket_val)
 
             self.assertEqual(len(variant_dict), len(self.exp_base_config))
             self.assertEqual(variant_dict["exp_1"], None)
@@ -946,7 +961,7 @@ class TestDeciderGetVariantAndExpose(unittest.TestCase):
             )
 
             self.assertEqual(self.event_logger.log.call_count, 0)
-            variant_dict = decider.get_all_variants_for_identifier_without_expose(identifier=identifier, identifier_type="device_id")
+            variant_dict = decider.get_all_variants_for_identifier_without_expose(identifier=identifier, identifier_type=bucket_val)
 
             self.assertEqual(len(variant_dict), len(self.exp_base_config))
             self.assertEqual(variant_dict["exp_1"], "variant_3")

--- a/tests/decider_tests.py
+++ b/tests/decider_tests.py
@@ -827,10 +827,12 @@ class TestDeciderGetVariantAndExpose(unittest.TestCase):
             self.assertEqual(self.event_logger.log.call_count, 0)
             variant_dict = decider.get_all_variants_without_expose()
 
-            self.assertEqual(len(variant_dict), len(self.exp_base_config))
-            self.assertEqual(variant_dict["exp_1"], None)
+            # "exp_1" returns variant None (due to "hg") and is excluded from the response dict
+            self.assertEqual(len(variant_dict), len(self.exp_base_config) - 1)
+            assert("exp_1" not in variant_dict)
             self.assertEqual(variant_dict["e1"], "e1treat")
             self.assertEqual(variant_dict["e2"], "e2treat")
+            self.assertEqual(variant_dict["hg"], "holdout")
 
             # exposure assertions
             self.assertEqual(self.event_logger.log.call_count, 1)
@@ -894,8 +896,9 @@ class TestDeciderGetVariantAndExpose(unittest.TestCase):
 
                 assert(any('Encountered error for experiment: exp_1 in decider.choose_all(): Missing "device_id" in context for bucket_val = "device_id"' in x.getMessage() for x in captured.records))
 
-                self.assertEqual(len(variant_dict), len(self.exp_base_config))
-                self.assertEqual(variant_dict["exp_1"], None)
+                # "exp_1" returns err() (due to bucket_val/`identifier_type` mismatch) and is excluded from the response dict
+                self.assertEqual(len(variant_dict), len(self.exp_base_config) - 1)
+                assert("exp_1" not in variant_dict)
                 self.assertEqual(variant_dict["e1"], "e1treat")
                 self.assertEqual(variant_dict["e2"], "e2treat")
 
@@ -927,10 +930,12 @@ class TestDeciderGetVariantAndExpose(unittest.TestCase):
             self.assertEqual(self.event_logger.log.call_count, 0)
             variant_dict = decider.get_all_variants_for_identifier_without_expose(identifier=identifier, identifier_type=bucket_val)
 
-            self.assertEqual(len(variant_dict), len(self.exp_base_config))
-            self.assertEqual(variant_dict["exp_1"], None)
+            # "exp_1" returns variant None (due to "hg") and is excluded from the response dict
+            self.assertEqual(len(variant_dict), len(self.exp_base_config) - 1)
+            assert("exp_1" not in variant_dict)
             self.assertEqual(variant_dict["e1"], "e1treat")
             self.assertEqual(variant_dict["e2"], "e2treat")
+            self.assertEqual(variant_dict["hg"], "holdout")
 
             # exposure assertions
             self.assertEqual(self.event_logger.log.call_count, 1)
@@ -999,10 +1004,12 @@ class TestDeciderGetVariantAndExpose(unittest.TestCase):
             self.assertEqual(self.event_logger.log.call_count, 0)
             variant_dict = decider.get_all_variants_for_identifier_without_expose(identifier=identifier, identifier_type=bucket_val)
 
-            self.assertEqual(len(variant_dict), len(self.exp_base_config))
-            self.assertEqual(variant_dict["exp_1"], None)
+            # "exp_1" returns variant None (due to "hg") and is excluded from the response dict
+            self.assertEqual(len(variant_dict), len(self.exp_base_config) - 1)
+            assert("exp_1" not in variant_dict)
             self.assertEqual(variant_dict["e1"], "e1treat")
             self.assertEqual(variant_dict["e2"], "e2treat")
+            self.assertEqual(variant_dict["hg"], "holdout")
 
             # exposure assertions
             self.assertEqual(self.event_logger.log.call_count, 1)
@@ -1071,10 +1078,12 @@ class TestDeciderGetVariantAndExpose(unittest.TestCase):
             self.assertEqual(self.event_logger.log.call_count, 0)
             variant_dict = decider.get_all_variants_for_identifier_without_expose(identifier=identifier, identifier_type=bucket_val)
 
-            self.assertEqual(len(variant_dict), len(self.exp_base_config))
-            self.assertEqual(variant_dict["exp_1"], None)
+            # "exp_1" returns variant None (due to "hg") and is excluded from the response dict
+            self.assertEqual(len(variant_dict), len(self.exp_base_config) - 1)
+            assert("exp_1" not in variant_dict)
             self.assertEqual(variant_dict["e1"], "e1treat")
             self.assertEqual(variant_dict["e2"], "e2treat")
+            self.assertEqual(variant_dict["hg"], "holdout")
 
             # exposure assertions
             self.assertEqual(self.event_logger.log.call_count, 1)


### PR DESCRIPTION
also ran flake8 for formatting cleanup.