### PR TITLE
Remove any IDENTIFIERS from decider `ctx` in `get_...for_identifier()` 

### DIFF
--- a/reddit_decider/__init__.py
+++ b/reddit_decider/__init__.py
@@ -22,7 +22,7 @@ import rust_decider
 logger = logging.getLogger(__name__)
 
 EMPLOYEE_ROLES = ("employee", "contractor")
-
+IDENTIFIERS = ("user_id", "device_id", "canonical_url")
 
 class EventType(Enum):
     EXPOSE = "expose"
@@ -386,7 +386,7 @@ class Decider:
         self,
         experiment_name: str,
         identifier: str,
-        identifier_type: Literal["user_id", "device_id", "canonical_url"],
+        identifier_type: Literal[IDENTIFIERS],
         **exposure_kwargs: Optional[Dict[str, Any]]
     ) -> Optional[str]:
         """Return a bucketing variant for identifier, if any, with auto-exposure.
@@ -413,10 +413,12 @@ class Decider:
             logger.error("Encountered error in _get_decider()")
             return None
 
-        identifier_context_fields = {
-            **self._decider_context.to_dict(),
-            **{identifier_type: identifier}
-        }
+        identifier_context_fields = self._decider_context.to_dict()
+        # reset any identifiers so only the the identifier passed in gets used
+        for id in IDENTIFIERS:
+            identifier_context_fields[id] = None
+
+        identifier_context_fields[identifier_type] = identifier
 
         ctx = rust_decider.make_ctx(identifier_context_fields)
         ctx_err = ctx.err()
@@ -471,7 +473,7 @@ class Decider:
         self,
         experiment_name: str,
         identifier: str,
-        identifier_type: Literal["user_id", "device_id", "canonical_url"]
+        identifier_type: Literal[IDENTIFIERS]
     ) -> Optional[str]:
         """Return a bucketing variant for `identifier`, if any, without emitting exposure event.
 
@@ -500,10 +502,12 @@ class Decider:
             logger.error("Encountered error in _get_decider()")
             return None
 
-        identifier_context_fields = {
-            **self._decider_context.to_dict(),
-            **{identifier_type: identifier}
-        }
+        identifier_context_fields = self._decider_context.to_dict()
+        # reset any identifiers so only the the identifier passed in gets used
+        for id in IDENTIFIERS:
+            identifier_context_fields[id] = None
+
+        identifier_context_fields[identifier_type] = identifier
 
         ctx = rust_decider.make_ctx(identifier_context_fields)
         ctx_err = ctx.err()
@@ -642,7 +646,7 @@ class Decider:
     def get_all_variants_for_identifier_without_expose(
         self,
         identifier: str,
-        identifier_type: Literal["user_id", "device_id", "canonical_url"]
+        identifier_type: Literal[IDENTIFIERS]
     ) -> Dict[str, Optional[str]]:
         """Return a dict of experiment name strings as keys and
             variant names as the values for `identifier`.
@@ -674,10 +678,12 @@ class Decider:
             logger.error("Encountered error in _get_decider()")
             return {}
 
-        identifier_context_fields = {
-            **self._decider_context.to_dict(),
-            **{identifier_type: identifier}
-        }
+        identifier_context_fields = self._decider_context.to_dict()
+        # reset any identifiers so only the the identifier passed in gets used
+        for id in IDENTIFIERS:
+            identifier_context_fields[id] = None
+
+        identifier_context_fields[identifier_type] = identifier
 
         ctx = rust_decider.make_ctx(identifier_context_fields)
         ctx_err = ctx.err()

--- a/reddit_decider/__init__.py
+++ b/reddit_decider/__init__.py
@@ -188,6 +188,15 @@ class Decider:
             logger.error("Could not load experiment config: %s", str(exc))
         return None
 
+    def _clear_identifiers_and_set(self, identifier: str, identifier_type: Literal[IDENTIFIERS]) -> Dict[str, Any]:
+        ctx = self._decider_context.to_dict()
+        # reset any identifiers so only the the identifier passed in gets used
+        for id in IDENTIFIERS:
+            ctx[id] = None
+
+        ctx[identifier_type] = identifier
+        return ctx
+
     def get_variant(
         self,
         experiment_name: str,
@@ -413,12 +422,9 @@ class Decider:
             logger.error("Encountered error in _get_decider()")
             return None
 
-        identifier_context_fields = self._decider_context.to_dict()
-        # reset any identifiers so only the the identifier passed in gets used
-        for id in IDENTIFIERS:
-            identifier_context_fields[id] = None
-
-        identifier_context_fields[identifier_type] = identifier
+        identifier_context_fields = self._clear_identifiers_and_set(
+            identifier=identifier, identifier_type=identifier_type
+        )
 
         ctx = rust_decider.make_ctx(identifier_context_fields)
         ctx_err = ctx.err()
@@ -502,10 +508,9 @@ class Decider:
             logger.error("Encountered error in _get_decider()")
             return None
 
-        identifier_context_fields = self._decider_context.to_dict()
-        # reset any identifiers so only the the identifier passed in gets used
-        for id in IDENTIFIERS:
-            identifier_context_fields[id] = None
+        identifier_context_fields = self._clear_identifiers_and_set(
+            identifier=identifier, identifier_type=identifier_type
+        )
 
         identifier_context_fields[identifier_type] = identifier
 
@@ -678,12 +683,9 @@ class Decider:
             logger.error("Encountered error in _get_decider()")
             return {}
 
-        identifier_context_fields = self._decider_context.to_dict()
-        # reset any identifiers so only the the identifier passed in gets used
-        for id in IDENTIFIERS:
-            identifier_context_fields[id] = None
-
-        identifier_context_fields[identifier_type] = identifier
+        identifier_context_fields = self._clear_identifiers_and_set(
+            identifier=identifier, identifier_type=identifier_type
+        )
 
         ctx = rust_decider.make_ctx(identifier_context_fields)
         ctx_err = ctx.err()

--- a/reddit_decider/__init__.py
+++ b/reddit_decider/__init__.py
@@ -512,8 +512,6 @@ class Decider:
             identifier=identifier, identifier_type=identifier_type
         )
 
-        identifier_context_fields[identifier_type] = identifier
-
         ctx = rust_decider.make_ctx(identifier_context_fields)
         ctx_err = ctx.err()
         if ctx_err is not None:


### PR DESCRIPTION
... before setting identifier, so there's no confusion as to which identifier is intended to be used based on `bucket_val` in json config (since identifiers can be set on DeciderContext, like user_id, even if asked to bucket `get_variant_for_identifier(...identifier_type="canoncial_url")`).
