### PR TITLE
Refactor exposure events

### DIFF
--- a/reddit_decider/__init__.py
+++ b/reddit_decider/__init__.py
@@ -248,8 +248,10 @@ class Decider:
             )
             return
 
+
+
         experiment = ExperimentConfig(
-            id=int(exp_id),
+            id=Decider._cast_to_int(exp_id),
             name=name,
             version=version,
             bucket_val=bucket_val,
@@ -298,7 +300,7 @@ class Decider:
         #   2: holdout
         if event_type == "2":
             experiment = ExperimentConfig(
-                id=int(exp_id),
+                id=Decider._cast_to_int(exp_id),
                 name=name,
                 version=version,
                 bucket_val=bucket_val,
@@ -319,6 +321,17 @@ class Decider:
                 **event_fields,
             )
         return
+
+    @classmethod
+    def _cast_to_int(cls, input: str) -> int:
+        id = 1
+        try:
+            id = int(input)
+        except ValueError as e:
+            logger.info(
+                f'Encountered error casting to integer: {e}'
+            )
+        return id
 
     def get_variant(
         self, experiment_name: str, **exposure_kwargs: Optional[Dict[str, Any]]
@@ -842,7 +855,7 @@ class DeciderContextFactory(ContextFactory):
                 extracted_fields = {}
 
             # prune any invalid keys/values in `extracted_fields` dict
-            parsed_extracted_fields = deepcopy(extracted_fields)
+            parsed_extracted_fields = extracted_fields.copy()
             for k, v in extracted_fields.items():
                 # remove invalid keys
                 if k is None or not isinstance(k, str):

--- a/reddit_decider/__init__.py
+++ b/reddit_decider/__init__.py
@@ -1,6 +1,6 @@
-from copy import deepcopy
 import logging
 
+from copy import deepcopy
 from dataclasses import dataclass
 from enum import Enum
 from typing import Any

--- a/reddit_decider/__init__.py
+++ b/reddit_decider/__init__.py
@@ -227,7 +227,9 @@ class Decider:
 
         return out
 
-    def _send_expose(self, event: str, exposure_fields: dict, overwrite_identifier: bool = False) -> None:
+    def _send_expose(
+        self, event: str, exposure_fields: dict, overwrite_identifier: bool = False
+    ) -> None:
         event_fields = deepcopy(exposure_fields)
         try:
             (

--- a/reddit_decider/__init__.py
+++ b/reddit_decider/__init__.py
@@ -248,8 +248,6 @@ class Decider:
             )
             return
 
-
-
         experiment = ExperimentConfig(
             id=Decider._cast_to_int(exp_id),
             name=name,
@@ -273,7 +271,9 @@ class Decider:
         )
         return
 
-    def _send_expose_if_holdout(self, event: str, exposure_fields: dict, overwrite_identifier: bool = False):
+    def _send_expose_if_holdout(
+        self, event: str, exposure_fields: dict, overwrite_identifier: bool = False
+    ):
         event_fields = deepcopy(exposure_fields)
         try:
             (
@@ -328,9 +328,7 @@ class Decider:
         try:
             id = int(input)
         except ValueError as e:
-            logger.info(
-                f'Encountered error casting to integer: {e}'
-            )
+            logger.info(f"Encountered error casting to integer: {e}")
         return id
 
     def get_variant(
@@ -524,7 +522,9 @@ class Decider:
         event_context_fields.update(exposure_kwargs or {})
 
         for event in choice.events():
-            self._send_expose(event=event, exposure_fields=event_context_fields, overwrite_identifier=True)
+            self._send_expose(
+                event=event, exposure_fields=event_context_fields, overwrite_identifier=True
+            )
 
         return variant
 
@@ -583,7 +583,9 @@ class Decider:
 
         # expose Holdout if the experiment is part of one
         for event in choice.events():
-            self._send_expose_if_holdout(event=event, exposure_fields=event_context_fields, overwrite_identifier=True)
+            self._send_expose_if_holdout(
+                event=event, exposure_fields=event_context_fields, overwrite_identifier=True
+            )
 
         return variant
 
@@ -718,7 +720,9 @@ class Decider:
 
             # expose Holdout if the experiment is part of one
             for event in choice.events():
-                self._send_expose_if_holdout(event=event, exposure_fields=event_context_fields, overwrite_identifier=True)
+                self._send_expose_if_holdout(
+                    event=event, exposure_fields=event_context_fields, overwrite_identifier=True
+                )
 
         return parsed_choices
 

--- a/reddit_decider/__init__.py
+++ b/reddit_decider/__init__.py
@@ -198,7 +198,7 @@ class Decider:
             logger.error("Could not load experiment config: %s", str(exc))
         return None
 
-    def _get_ctx(self) -> T:
+    def _get_ctx(self) -> Any:
         context_fields = self._decider_context.to_dict()
         return rust_decider.make_ctx(context_fields)
 
@@ -227,7 +227,7 @@ class Decider:
 
         return out
 
-    def _send_expose(self, event: str, exposure_fields: dict, overwrite_identifier: bool = False):
+    def _send_expose(self, event: str, exposure_fields: dict, overwrite_identifier: bool = False) -> None:
         event_fields = deepcopy(exposure_fields)
         try:
             (
@@ -253,8 +253,8 @@ class Decider:
             name=name,
             version=version,
             bucket_val=bucket_val,
-            start_ts=start_ts,
-            stop_ts=stop_ts,
+            start_ts=Decider._cast_to_int(start_ts),
+            stop_ts=Decider._cast_to_int(stop_ts),
             owner=owner,
         )
 
@@ -273,7 +273,7 @@ class Decider:
 
     def _send_expose_if_holdout(
         self, event: str, exposure_fields: dict, overwrite_identifier: bool = False
-    ):
+    ) -> None:
         event_fields = deepcopy(exposure_fields)
         try:
             (
@@ -304,8 +304,8 @@ class Decider:
                 name=name,
                 version=version,
                 bucket_val=bucket_val,
-                start_ts=start_ts,
-                stop_ts=stop_ts,
+                start_ts=Decider._cast_to_int(start_ts),
+                stop_ts=Decider._cast_to_int(stop_ts),
                 owner=owner,
             )
 
@@ -324,12 +324,12 @@ class Decider:
 
     @classmethod
     def _cast_to_int(cls, input: str) -> int:
-        id = 1
+        out = 1
         try:
-            id = int(input)
+            out = int(input)
         except ValueError as e:
             logger.info(f"Encountered error casting to integer: {e}")
-        return id
+        return out
 
     def get_variant(
         self, experiment_name: str, **exposure_kwargs: Optional[Dict[str, Any]]

--- a/reddit_decider/__init__.py
+++ b/reddit_decider/__init__.py
@@ -203,9 +203,9 @@ class Decider:
         return rust_decider.make_ctx(context_fields)
 
     def _clear_ctx_identifiers_and_set(
-        self, ctx_dict: dict, identifier: str, identifier_type: Literal["user_id", "device_id", "canonical_url"]
+        self, identifier: str, identifier_type: Literal["user_id", "device_id", "canonical_url"]
     ) -> Dict[str, Any]:
-        ctx = deepcopy(ctx_dict)
+        ctx = self._decider_context.to_dict()
         # reset any identifiers so only the the identifier passed in gets used
         for id in IDENTIFIERS:
             ctx[id] = None
@@ -404,7 +404,7 @@ class Decider:
 
         # expose Holdout if the experiment is part of one
         for event in choice.events():
-            self._send_expose_if_holdout(event=event, exposure_fields=event_context_fields, overwrite_identifier=True)
+            self._send_expose_if_holdout(event=event, exposure_fields=event_context_fields)
 
         return variant
 
@@ -489,7 +489,7 @@ class Decider:
             return None
 
         identifier_context_fields = self._clear_ctx_identifiers_and_set(
-            ctx_dict=self._decider_context.to_dict(), identifier=identifier, identifier_type=identifier_type
+            identifier=identifier, identifier_type=identifier_type
         )
 
         ctx = rust_decider.make_ctx(identifier_context_fields)
@@ -548,7 +548,7 @@ class Decider:
             return None
 
         identifier_context_fields = self._clear_ctx_identifiers_and_set(
-            ctx_dict=self._decider_context.to_dict(), identifier=identifier, identifier_type=identifier_type
+            identifier=identifier, identifier_type=identifier_type
         )
 
         ctx = rust_decider.make_ctx(identifier_context_fields)
@@ -676,7 +676,7 @@ class Decider:
             return []
 
         identifier_context_fields = self._clear_ctx_identifiers_and_set(
-            ctx_dict=self._decider_context.to_dict(), identifier=identifier, identifier_type=identifier_type
+            identifier=identifier, identifier_type=identifier_type
         )
 
         ctx = rust_decider.make_ctx(identifier_context_fields)

--- a/reddit_decider/__init__.py
+++ b/reddit_decider/__init__.py
@@ -156,7 +156,7 @@ def validate_decider(decider: Optional[Any]) -> None:
     if decider:
         decider_err = decider.err()
         if decider_err:
-            logger.error(f"Rust decider has error: {decider_err}")
+            logger.error(f"Rust decider has initialization error: {decider_err}")
 
 
 class Decider:
@@ -196,6 +196,10 @@ class Decider:
         except TypeError as exc:
             logger.error("Could not load experiment config: %s", str(exc))
         return None
+
+    def _get_ctx(self) -> T:
+        context_fields = self._decider_context.to_dict()
+        return rust_decider.make_ctx(context_fields)
 
     def _clear_identifiers_and_set(
         self, identifier: str, identifier_type: Literal["user_id", "device_id", "canonical_url"]
@@ -243,11 +247,9 @@ class Decider:
         """
         decider = self._get_decider()
         if decider is None:
-            logger.error("Encountered error in _get_decider()")
             return None
 
-        context_fields = self._decider_context.to_dict()
-        ctx = rust_decider.make_ctx(context_fields)
+        ctx = self._get_ctx()
         ctx_err = ctx.err()
         if ctx_err is not None:
             logger.info(f"Encountered error in rust_decider.make_ctx(): {ctx_err}")
@@ -323,11 +325,9 @@ class Decider:
         """
         decider = self._get_decider()
         if decider is None:
-            logger.error("Encountered error in _get_decider()")
             return None
 
-        context_fields = self._decider_context.to_dict()
-        ctx = rust_decider.make_ctx(context_fields)
+        ctx = self._get_ctx()
         ctx_err = ctx.err()
         if ctx_err is not None:
             logger.info(f"Encountered error in rust_decider.make_ctx(): {ctx_err}")
@@ -408,7 +408,6 @@ class Decider:
         """
         decider = self._get_decider()
         if decider is None:
-            logger.error("Encountered error in _get_decider()")
             return
 
         experiment = decider.get_experiment(experiment_name)
@@ -468,7 +467,6 @@ class Decider:
         """
         decider = self._get_decider()
         if decider is None:
-            logger.error("Encountered error in _get_decider()")
             return None
 
         identifier_context_fields = self._clear_identifiers_and_set(
@@ -567,7 +565,6 @@ class Decider:
         """
         decider = self._get_decider()
         if decider is None:
-            logger.error("Encountered error in _get_decider()")
             return None
 
         identifier_context_fields = self._clear_identifiers_and_set(
@@ -670,11 +667,9 @@ class Decider:
         """
         decider = self._get_decider()
         if decider is None:
-            logger.error("Encountered error in _get_decider()")
             return []
 
-        context_fields = self._decider_context.to_dict()
-        ctx = rust_decider.make_ctx(context_fields)
+        ctx = self._get_ctx()
         ctx_err = ctx.err()
         if ctx_err is not None:
             logger.info(f"Encountered error in rust_decider.make_ctx(): {ctx_err}")
@@ -783,7 +778,6 @@ class Decider:
         """
         decider = self._get_decider()
         if decider is None:
-            logger.error("Encountered error in _get_decider()")
             return []
 
         identifier_context_fields = self._clear_identifiers_and_set(
@@ -870,8 +864,7 @@ class Decider:
         decider_func: Callable[[str, DeciderContext], Any],
         default: Any,
     ) -> Optional[Any]:
-        context_fields = self._decider_context.to_dict()
-        ctx = rust_decider.make_ctx(context_fields)
+        ctx = self._get_ctx()
         ctx_err = ctx.err()
         if ctx_err is not None:
             logger.info(f"Encountered error in rust_decider.make_ctx(): {ctx_err}")
@@ -890,35 +883,30 @@ class Decider:
     def get_bool(self, feature_name: str, default: bool = False) -> bool:
         decider = self._get_decider()
         if not decider:
-            logger.error("Encountered error in _get_decider()")
             return default
         return self._get_dynamic_config_value(feature_name, decider.get_bool, default)
 
     def get_int(self, feature_name: str, default: int = 0) -> int:
         decider = self._get_decider()
         if not decider:
-            logger.error("Encountered error in _get_decider()")
             return default
         return self._get_dynamic_config_value(feature_name, decider.get_int, default)
 
     def get_float(self, feature_name: str, default: float = 0.0) -> float:
         decider = self._get_decider()
         if not decider:
-            logger.error("Encountered error in _get_decider()")
             return default
         return self._get_dynamic_config_value(feature_name, decider.get_float, default)
 
     def get_string(self, feature_name: str, default: str = "") -> str:
         decider = self._get_decider()
         if not decider:
-            logger.error("Encountered error in _get_decider()")
             return default
         return self._get_dynamic_config_value(feature_name, decider.get_string, default)
 
     def get_map(self, feature_name: str, default: Optional[dict] = None) -> Optional[dict]:
         decider = self._get_decider()
         if not decider:
-            logger.error("Encountered error in _get_decider()")
             return default
         return self._get_dynamic_config_value(feature_name, decider.get_map, default)
 

--- a/tests/decider_tests.py
+++ b/tests/decider_tests.py
@@ -461,8 +461,9 @@ class TestDeciderGetVariantAndExpose(unittest.TestCase):
                 self.assertEqual(variant, None)
                 self.assertEqual(self.event_logger.log.call_count, 0)
 
+                print([x.getMessage() for x in captured.records])
                 assert any(
-                    'Rust decider has initialization error: Decider initialization failed: Json error: "invalid type: string \\"1\\"'
+                    'Rust decider has initialization error: Json error: "invalid type: string \\"1\\"'
                     in x.getMessage()
                     for x in captured.records
                 )

--- a/tests/decider_tests.py
+++ b/tests/decider_tests.py
@@ -455,9 +455,17 @@ class TestDeciderGetVariantAndExpose(unittest.TestCase):
                 event_logger=self.event_logger,
             )
 
-            variant = decider.get_variant("test")
-            self.assertEqual(self.event_logger.log.call_count, 0)
-            self.assertEqual(variant, None)
+            with self.assertLogs() as captured:
+                variant = decider.get_variant("test")
+
+                self.assertEqual(variant, None)
+                self.assertEqual(self.event_logger.log.call_count, 0)
+
+                assert any(
+                    'Rust decider has initialization error: Decider initialization failed: Json error: "invalid type: string \\"1\\"'
+                    in x.getMessage()
+                    for x in captured.records
+                )
 
     def test_none_returned_on_get_variant_call_with_no_experiment_data(self):
         config = {


### PR DESCRIPTION
Extract identical code used to send exposure for each event in `.events()` array into `_send_expose()` & `_send_expose_if_holdout()` functions.

Introduce `_get_ctx()` to remove some repeated code.

Leverage deepcopy.

Remove extra `logger.error("Encountered error in _get_decider()")` lines since errors are already printed in `_get_decider()` itself.