### PR TITLE
Don't clear identifiers in `..._for_identifier_...()` and pass through `identifier_type` to rust

### DIFF
--- a/reddit_decider/__init__.py
+++ b/reddit_decider/__init__.py
@@ -741,7 +741,7 @@ class Decider:
             logger.info(f"Encountered error in rust_decider.make_ctx(): {ctx_err}")
             return []
 
-        all_choice_result = decider.choose_all(ctx)
+        all_choice_result = decider.choose_all(ctx, identifier_type=identifier_type)
 
         error = all_choice_result.err()
         if error:

--- a/reddit_decider/__init__.py
+++ b/reddit_decider/__init__.py
@@ -515,7 +515,7 @@ class Decider:
         :return: Variant name if a variant is assigned, None otherwise.
         """
         if identifier_type not in IDENTIFIERS:
-            logger.warning(f'"{identifier_type}" is not a supported "identifier_type", use one of {IDENTIFIERS}.')
+            logger.warning(f'"{identifier_type}" is not one of supported "identifier_type": {IDENTIFIERS}.')
             return None
 
         decider = self._get_decider()
@@ -577,7 +577,7 @@ class Decider:
         :return: Variant name if a variant is assigned, None otherwise.
         """
         if identifier_type not in IDENTIFIERS:
-            logger.warning(f'"{identifier_type}" is not a supported "identifier_type", use one of {IDENTIFIERS}.')
+            logger.warning(f'"{identifier_type}" is not one of supported "identifier_type": {IDENTIFIERS}.')
             return None
 
         decider = self._get_decider()
@@ -713,7 +713,7 @@ class Decider:
         :return: list of experiment dicts with non-`None` variants.
         """
         if identifier_type not in IDENTIFIERS:
-            logger.warning(f'"{identifier_type}" is not a supported "identifier_type", use one of {IDENTIFIERS}.')
+            logger.warning(f'"{identifier_type}" is not one of supported "identifier_type": {IDENTIFIERS}.')
             return []
 
         decider = self._get_decider()

--- a/reddit_decider/__init__.py
+++ b/reddit_decider/__init__.py
@@ -515,21 +515,26 @@ class Decider:
         :return: Variant name if a variant is assigned, None otherwise.
         """
         if identifier_type not in IDENTIFIERS:
-            logger.warning(f'"{identifier_type}" is not one of supported "identifier_type": {IDENTIFIERS}.')
+            logger.warning(
+                f'"{identifier_type}" is not one of supported "identifier_type": {IDENTIFIERS}.'
+            )
             return None
 
         decider = self._get_decider()
         if decider is None:
             return None
 
-        ctx = self._get_ctx_with_set_identifier(identifier=identifier, identifier_type=identifier_type)
+        ctx = self._get_ctx_with_set_identifier(
+            identifier=identifier, identifier_type=identifier_type
+        )
         ctx_err = ctx.err()
         if ctx_err is not None:
             logger.info(f"Encountered error in rust_decider.make_ctx(): {ctx_err}")
             return None
 
-
-        choice = decider.choose(feature_name=experiment_name, ctx=ctx, identifier_type=identifier_type)
+        choice = decider.choose(
+            feature_name=experiment_name, ctx=ctx, identifier_type=identifier_type
+        )
         error = choice.err()
 
         if error:
@@ -577,20 +582,26 @@ class Decider:
         :return: Variant name if a variant is assigned, None otherwise.
         """
         if identifier_type not in IDENTIFIERS:
-            logger.warning(f'"{identifier_type}" is not one of supported "identifier_type": {IDENTIFIERS}.')
+            logger.warning(
+                f'"{identifier_type}" is not one of supported "identifier_type": {IDENTIFIERS}.'
+            )
             return None
 
         decider = self._get_decider()
         if decider is None:
             return None
 
-        ctx = self._get_ctx_with_set_identifier(identifier=identifier, identifier_type=identifier_type)
+        ctx = self._get_ctx_with_set_identifier(
+            identifier=identifier, identifier_type=identifier_type
+        )
         ctx_err = ctx.err()
         if ctx_err is not None:
             logger.info(f"Encountered error in rust_decider.make_ctx(): {ctx_err}")
             return None
 
-        choice = decider.choose(feature_name=experiment_name, ctx=ctx, identifier_type=identifier_type)
+        choice = decider.choose(
+            feature_name=experiment_name, ctx=ctx, identifier_type=identifier_type
+        )
         error = choice.err()
         if error:
             logger.info(f"Encountered error in decider.choose(): {error}")
@@ -713,14 +724,18 @@ class Decider:
         :return: list of experiment dicts with non-`None` variants.
         """
         if identifier_type not in IDENTIFIERS:
-            logger.warning(f'"{identifier_type}" is not one of supported "identifier_type": {IDENTIFIERS}.')
+            logger.warning(
+                f'"{identifier_type}" is not one of supported "identifier_type": {IDENTIFIERS}.'
+            )
             return []
 
         decider = self._get_decider()
         if decider is None:
             return []
 
-        ctx = self._get_ctx_with_set_identifier(identifier=identifier, identifier_type=identifier_type)
+        ctx = self._get_ctx_with_set_identifier(
+            identifier=identifier, identifier_type=identifier_type
+        )
         ctx_err = ctx.err()
         if ctx_err is not None:
             logger.info(f"Encountered error in rust_decider.make_ctx(): {ctx_err}")

--- a/reddit_decider/__init__.py
+++ b/reddit_decider/__init__.py
@@ -661,7 +661,7 @@ class Decider:
         error = all_choice_result.err()
         if error:
             logger.info(f"Encountered error in decider.choose_all(): {error}")
-            return None
+            return []
 
         all_choices = all_choice_result.decisions()
         parsed_choices = []
@@ -746,7 +746,7 @@ class Decider:
         error = all_choice_result.err()
         if error:
             logger.info(f"Encountered error in decider.choose_all(): {error}")
-            return None
+            return []
 
         all_choices = all_choice_result.decisions()
         parsed_choices = []

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 alabaster==0.7.12
 baseplate==2.0.0a1
 black==21.4b2
-reddit-decider==1.1.23
+reddit-decider==1.2.0
 flake8==3.9.1
 mypy==0.790
 pyramid==2.0   # required for `from baseplate.frameworks.pyramid import BaseplateRequest` which calls `import pyramid.events`

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     install_requires=[
         "baseplate>=2.0.0a1,<3.0",
         "reddit-edgecontext>=1.0.0a3,<2.0",
-        "reddit-decider>=1.1.23",
+        "reddit-decider>=1.2.0",
     ],
     package_data={"reddit_experiments": ["py.typed"]},
     zip_safe=True,

--- a/tests/decider_tests.py
+++ b/tests/decider_tests.py
@@ -1073,31 +1073,25 @@ class TestDeciderGetVariantAndExpose(unittest.TestCase):
             )
 
             self.assertEqual(self.event_logger.log.call_count, 0)
-            with self.assertLogs() as captured:
-                variant_arr = decider.get_all_variants_for_identifier_without_expose(
-                    identifier=identifier, identifier_type=bucket_val
-                )
 
-                assert any(
-                    'Encountered error for experiment: exp_1 in decider.choose_all(): Missing "device_id" in context for bucket_val = "device_id"'
-                    in x.getMessage()
-                    for x in captured.records
-                )
+            variant_arr = decider.get_all_variants_for_identifier_without_expose(
+                identifier=identifier, identifier_type=bucket_val
+            )
 
-                # "exp_1" returns err() (due to bucket_val/`identifier_type` mismatch) and is excluded from the response dict
-                self.assertEqual(len(variant_arr), len(self.exp_base_config) - 1)
-                self.assertEqual(self.first_experimentName_occurrence(variant_arr, "exp_1"), None)
-                self.assertEqual(
-                    self.first_experimentName_occurrence(variant_arr, "e1"),
-                    {"id": 6, "name": "e1treat", "version": "4", "experimentName": "e1"},
-                )
-                self.assertEqual(
-                    self.first_experimentName_occurrence(variant_arr, "e2"),
-                    {"id": 7, "name": "e2treat", "version": "5", "experimentName": "e2"},
-                )
+            # "exp_1" returns err() (due to bucket_val/`identifier_type` mismatch) and is excluded from the response dict
+            self.assertEqual(len(variant_arr), len(self.exp_base_config) - 1)
+            self.assertEqual(self.first_experimentName_occurrence(variant_arr, "exp_1"), None)
+            self.assertEqual(
+                self.first_experimentName_occurrence(variant_arr, "e1"),
+                {"id": 6, "name": "e1treat", "version": "4", "experimentName": "e1"},
+            )
+            self.assertEqual(
+                self.first_experimentName_occurrence(variant_arr, "e2"),
+                {"id": 7, "name": "e2treat", "version": "5", "experimentName": "e2"},
+            )
 
-                # no exposures should be triggered
-                self.assertEqual(self.event_logger.log.call_count, 0)
+            # no exposures should be triggered
+            self.assertEqual(self.event_logger.log.call_count, 0)
 
     def test_get_all_variants_for_identifier_without_expose_user_id_with_hg(self):
         identifier = USER_ID

--- a/tests/decider_tests.py
+++ b/tests/decider_tests.py
@@ -721,7 +721,7 @@ class TestDeciderGetVariantAndExpose(unittest.TestCase):
                 self.assertEqual(variant, None)
 
                 assert any(
-                    '"blah" is not a supported "identifier_type", use one of [\'user_id\', \'device_id\', \'canonical_url\'].'
+                    '"blah" is not one of supported "identifier_type": [\'user_id\', \'device_id\', \'canonical_url\'].'
                     in x.getMessage()
                     for x in captured.records
                 )
@@ -913,7 +913,7 @@ class TestDeciderGetVariantAndExpose(unittest.TestCase):
                 self.assertEqual(variant, None)
 
                 assert any(
-                    '"blah" is not a supported "identifier_type", use one of [\'user_id\', \'device_id\', \'canonical_url\'].'
+                    '"blah" is not one of supported "identifier_type": [\'user_id\', \'device_id\', \'canonical_url\'].'
                     in x.getMessage()
                     for x in captured.records
                 )
@@ -1372,7 +1372,7 @@ class TestDeciderGetVariantAndExpose(unittest.TestCase):
                 self.assertEqual(len(variant_arr), 0)
 
                 assert any(
-                    '"blah" is not a supported "identifier_type", use one of [\'user_id\', \'device_id\', \'canonical_url\'].'
+                    '"blah" is not one of supported "identifier_type": [\'user_id\', \'device_id\', \'canonical_url\'].'
                     in x.getMessage()
                     for x in captured.records
                 )

--- a/tests/decider_tests.py
+++ b/tests/decider_tests.py
@@ -461,9 +461,8 @@ class TestDeciderGetVariantAndExpose(unittest.TestCase):
                 self.assertEqual(variant, None)
                 self.assertEqual(self.event_logger.log.call_count, 0)
 
-                print([x.getMessage() for x in captured.records])
                 assert any(
-                    'Rust decider has initialization error: Json error: "invalid type: string \\"1\\"'
+                    'Rust decider has initialization error: Decider initialization failed: Json error: "invalid type: string \\"1\\"'
                     in x.getMessage()
                     for x in captured.records
                 )
@@ -690,12 +689,45 @@ class TestDeciderGetVariantAndExpose(unittest.TestCase):
                 self.assertEqual(variant, None)
                 # exposure isn't emitted either
                 self.assertEqual(self.event_logger.log.call_count, 0)
-
+                print([x.getMessage() for x in captured.records])
                 assert any(
-                    'Encountered error in decider.choose(): Missing "device_id" in context for bucket_val = "device_id"'
+                    'Requested identifier_type: "canonical_url" is incompatible with experiment\'s "bucket_val" = "device_id".'
                     in x.getMessage()
                     for x in captured.records
                 )
+
+    def test_get_variant_for_identifier_bogus_identifier_type(self):
+        identifier = "anything"
+        identifier_type = "blah"
+
+        with create_temp_config_file(self.exp_base_config) as f:
+            filewatcher = FileWatcher(path=f.name, parser=init_decider_parser, timeout=2, backoff=2)
+
+            decider = Decider(
+                decider_context=self.minimal_decider_context,
+                config_watcher=filewatcher,
+                server_span=self.mock_span,
+                context_name="test",
+                event_logger=self.event_logger,
+            )
+
+            self.assertEqual(self.event_logger.log.call_count, 0)
+            with self.assertLogs() as captured:
+                # `identifier_type="canonical_url"`, which doesn't match `bucket_val` of `device_id`
+                variant = decider.get_variant_for_identifier(
+                    experiment_name="exp_1", identifier=identifier, identifier_type=identifier_type
+                )
+                # `None` is returned since `identifier_type` doesn't match `bucket_val` in experiment-config json
+                self.assertEqual(variant, None)
+
+                assert any(
+                    '"blah" is not a supported "identifier_type", use one of [\'user_id\', \'device_id\', \'canonical_url\'].'
+                    in x.getMessage()
+                    for x in captured.records
+                )
+
+        # exposure isn't emitted either
+        self.assertEqual(self.event_logger.log.call_count, 0)
 
     def test_expose(self):
         with create_temp_config_file(self.exp_base_config) as f:
@@ -853,6 +885,38 @@ class TestDeciderGetVariantAndExpose(unittest.TestCase):
                 experiment_name="exp_1", identifier=identifier, identifier_type="device_id"
             )
             self.assertEqual(variant, "variant_3")
+
+            # no exposures should be triggered
+            self.assertEqual(self.event_logger.log.call_count, 0)
+
+    def test_get_variant_for_identifier_without_expose_bogus_identifier_type(self):
+        identifier = "anything"
+        identifier_type = "blah"
+
+        with create_temp_config_file(self.exp_base_config) as f:
+            filewatcher = FileWatcher(path=f.name, parser=init_decider_parser, timeout=2, backoff=2)
+
+            decider = Decider(
+                decider_context=self.dc,
+                config_watcher=filewatcher,
+                server_span=self.mock_span,
+                context_name="test",
+                event_logger=self.event_logger,
+            )
+
+            self.assertEqual(self.event_logger.log.call_count, 0)
+            with self.assertLogs() as captured:
+                variant = decider.get_variant_for_identifier_without_expose(
+                    experiment_name="exp_1", identifier=identifier, identifier_type=identifier_type
+                )
+
+                self.assertEqual(variant, None)
+
+                assert any(
+                    '"blah" is not a supported "identifier_type", use one of [\'user_id\', \'device_id\', \'canonical_url\'].'
+                    in x.getMessage()
+                    for x in captured.records
+                )
 
             # no exposures should be triggered
             self.assertEqual(self.event_logger.log.call_count, 0)
@@ -1281,6 +1345,40 @@ class TestDeciderGetVariantAndExpose(unittest.TestCase):
                 bucket_val=bucket_val,
                 identifier=identifier,
             )
+
+    def test_get_all_variants_for_identifier_without_expose_bogus_identifier_type(self):
+        identifier = "anything"
+        # use non-supported `identifier_type`
+        identifier_type = "blah"
+
+        with create_temp_config_file(self.exp_base_config) as f:
+            filewatcher = FileWatcher(path=f.name, parser=init_decider_parser, timeout=2, backoff=2)
+
+            decider = Decider(
+                decider_context=self.minimal_decider_context,
+                config_watcher=filewatcher,
+                server_span=self.mock_span,
+                context_name="test",
+                event_logger=self.event_logger,
+            )
+
+            self.assertEqual(self.event_logger.log.call_count, 0)
+
+            with self.assertLogs() as captured:
+                variant_arr = decider.get_all_variants_for_identifier_without_expose(
+                    identifier=identifier, identifier_type="blah"
+                )
+
+                self.assertEqual(len(variant_arr), 0)
+
+                assert any(
+                    '"blah" is not a supported "identifier_type", use one of [\'user_id\', \'device_id\', \'canonical_url\'].'
+                    in x.getMessage()
+                    for x in captured.records
+                )
+
+            # no exposures should be triggered
+            self.assertEqual(self.event_logger.log.call_count, 0)
 
     def test_get_variant_with_exposure_kwargs(self):
         with create_temp_config_file(self.exp_base_config) as f:

--- a/tests/decider_tests.py
+++ b/tests/decider_tests.py
@@ -721,7 +721,7 @@ class TestDeciderGetVariantAndExpose(unittest.TestCase):
                 self.assertEqual(variant, None)
 
                 assert any(
-                    '"blah" is not one of supported "identifier_type": [\'user_id\', \'device_id\', \'canonical_url\'].'
+                    "\"blah\" is not one of supported \"identifier_type\": ['user_id', 'device_id', 'canonical_url']."
                     in x.getMessage()
                     for x in captured.records
                 )
@@ -913,7 +913,7 @@ class TestDeciderGetVariantAndExpose(unittest.TestCase):
                 self.assertEqual(variant, None)
 
                 assert any(
-                    '"blah" is not one of supported "identifier_type": [\'user_id\', \'device_id\', \'canonical_url\'].'
+                    "\"blah\" is not one of supported \"identifier_type\": ['user_id', 'device_id', 'canonical_url']."
                     in x.getMessage()
                     for x in captured.records
                 )
@@ -1372,7 +1372,7 @@ class TestDeciderGetVariantAndExpose(unittest.TestCase):
                 self.assertEqual(len(variant_arr), 0)
 
                 assert any(
-                    '"blah" is not one of supported "identifier_type": [\'user_id\', \'device_id\', \'canonical_url\'].'
+                    "\"blah\" is not one of supported \"identifier_type\": ['user_id', 'device_id', 'canonical_url']."
                     in x.getMessage()
                     for x in captured.records
                 )

--- a/tests/decider_tests.py
+++ b/tests/decider_tests.py
@@ -565,7 +565,7 @@ class TestDeciderGetVariantAndExpose(unittest.TestCase):
             filewatcher = FileWatcher(path=f.name, parser=init_decider_parser, timeout=2, backoff=2)
 
             decider = Decider(
-                decider_context=self.minimal_decider_context,
+                decider_context=self.dc,
                 config_watcher=filewatcher,
                 server_span=self.mock_span,
                 context_name="test",
@@ -600,7 +600,7 @@ class TestDeciderGetVariantAndExpose(unittest.TestCase):
             filewatcher = FileWatcher(path=f.name, parser=init_decider_parser, timeout=2, backoff=2)
 
             decider = Decider(
-                decider_context=self.minimal_decider_context,
+                decider_context=self.dc,
                 config_watcher=filewatcher,
                 server_span=self.mock_span,
                 context_name="test",
@@ -636,7 +636,7 @@ class TestDeciderGetVariantAndExpose(unittest.TestCase):
             filewatcher = FileWatcher(path=f.name, parser=init_decider_parser, timeout=2, backoff=2)
 
             decider = Decider(
-                decider_context=self.minimal_decider_context,
+                decider_context=self.dc,
                 config_watcher=filewatcher,
                 server_span=self.mock_span,
                 context_name="test",
@@ -672,7 +672,7 @@ class TestDeciderGetVariantAndExpose(unittest.TestCase):
             filewatcher = FileWatcher(path=f.name, parser=init_decider_parser, timeout=2, backoff=2)
 
             decider = Decider(
-                decider_context=self.minimal_decider_context,
+                decider_context=self.dc,
                 config_watcher=filewatcher,
                 server_span=self.mock_span,
                 context_name="test",
@@ -689,7 +689,7 @@ class TestDeciderGetVariantAndExpose(unittest.TestCase):
                 self.assertEqual(variant, None)
                 # exposure isn't emitted either
                 self.assertEqual(self.event_logger.log.call_count, 0)
-                print([x.getMessage() for x in captured.records])
+
                 assert any(
                     'Requested identifier_type: "canonical_url" is incompatible with experiment\'s "bucket_val" = "device_id".'
                     in x.getMessage()
@@ -760,7 +760,7 @@ class TestDeciderGetVariantAndExpose(unittest.TestCase):
             filewatcher = FileWatcher(path=f.name, parser=init_decider_parser, timeout=2, backoff=2)
 
             decider = Decider(
-                decider_context=self.minimal_decider_context,
+                decider_context=self.dc,
                 config_watcher=filewatcher,
                 server_span=self.mock_span,
                 context_name="test",
@@ -787,7 +787,7 @@ class TestDeciderGetVariantAndExpose(unittest.TestCase):
             filewatcher = FileWatcher(path=f.name, parser=init_decider_parser, timeout=2, backoff=2)
 
             decider = Decider(
-                decider_context=self.minimal_decider_context,
+                decider_context=self.dc,
                 config_watcher=filewatcher,
                 server_span=self.mock_span,
                 context_name="test",
@@ -823,7 +823,7 @@ class TestDeciderGetVariantAndExpose(unittest.TestCase):
             filewatcher = FileWatcher(path=f.name, parser=init_decider_parser, timeout=2, backoff=2)
 
             decider = Decider(
-                decider_context=self.minimal_decider_context,
+                decider_context=self.dc,
                 config_watcher=filewatcher,
                 server_span=self.mock_span,
                 context_name="test",
@@ -832,11 +832,20 @@ class TestDeciderGetVariantAndExpose(unittest.TestCase):
 
             self.assertEqual(self.event_logger.log.call_count, 0)
             # `identifier_type="canonical_url"`, which doesn't match `bucket_val` of `device_id`
-            variant = decider.get_variant_for_identifier_without_expose(
-                experiment_name="exp_1", identifier=identifier, identifier_type="canonical_url"
-            )
-            # `None` is returned since `identifier_type` doesn't match `bucket_val` in experiment-config json
-            self.assertEqual(variant, None)
+            self.assertEqual(self.event_logger.log.call_count, 0)
+            with self.assertLogs() as captured:
+                variant = decider.get_variant_for_identifier_without_expose(
+                    experiment_name="exp_1", identifier=identifier, identifier_type="canonical_url"
+                )
+                # `None` is returned since `identifier_type` doesn't match `bucket_val` in experiment-config json
+                self.assertEqual(variant, None)
+
+                assert any(
+                    'Encountered error in decider.choose(): Requested identifier_type: "canonical_url" is incompatible with experiment\'s "bucket_val" = "device_id".'
+                    in x.getMessage()
+                    for x in captured.records
+                )
+
             self.assertEqual(self.event_logger.log.call_count, 0)
 
     def test_get_variant_for_identifier_without_expose_canonical_url(self):
@@ -848,7 +857,7 @@ class TestDeciderGetVariantAndExpose(unittest.TestCase):
             filewatcher = FileWatcher(path=f.name, parser=init_decider_parser, timeout=2, backoff=2)
 
             decider = Decider(
-                decider_context=self.minimal_decider_context,
+                decider_context=self.dc,
                 config_watcher=filewatcher,
                 server_span=self.mock_span,
                 context_name="test",
@@ -873,7 +882,7 @@ class TestDeciderGetVariantAndExpose(unittest.TestCase):
             filewatcher = FileWatcher(path=f.name, parser=init_decider_parser, timeout=2, backoff=2)
 
             decider = Decider(
-                decider_context=self.minimal_decider_context,
+                decider_context=self.dc,
                 config_watcher=filewatcher,
                 server_span=self.mock_span,
                 context_name="test",
@@ -1014,7 +1023,7 @@ class TestDeciderGetVariantAndExpose(unittest.TestCase):
             filewatcher = FileWatcher(path=f.name, parser=init_decider_parser, timeout=2, backoff=2)
 
             decider = Decider(
-                decider_context=self.minimal_decider_context,
+                decider_context=self.dc,
                 config_watcher=filewatcher,
                 server_span=self.mock_span,
                 context_name="test",
@@ -1105,7 +1114,7 @@ class TestDeciderGetVariantAndExpose(unittest.TestCase):
             filewatcher = FileWatcher(path=f.name, parser=init_decider_parser, timeout=2, backoff=2)
 
             decider = Decider(
-                decider_context=self.minimal_decider_context,
+                decider_context=self.dc,
                 config_watcher=filewatcher,
                 server_span=self.mock_span,
                 context_name="test",
@@ -1156,7 +1165,7 @@ class TestDeciderGetVariantAndExpose(unittest.TestCase):
             filewatcher = FileWatcher(path=f.name, parser=init_decider_parser, timeout=2, backoff=2)
 
             decider = Decider(
-                decider_context=self.minimal_decider_context,
+                decider_context=self.dc,
                 config_watcher=filewatcher,
                 server_span=self.mock_span,
                 context_name="test",
@@ -1203,7 +1212,7 @@ class TestDeciderGetVariantAndExpose(unittest.TestCase):
             filewatcher = FileWatcher(path=f.name, parser=init_decider_parser, timeout=2, backoff=2)
 
             decider = Decider(
-                decider_context=self.minimal_decider_context,
+                decider_context=self.dc,
                 config_watcher=filewatcher,
                 server_span=self.mock_span,
                 context_name="test",
@@ -1258,7 +1267,7 @@ class TestDeciderGetVariantAndExpose(unittest.TestCase):
             filewatcher = FileWatcher(path=f.name, parser=init_decider_parser, timeout=2, backoff=2)
 
             decider = Decider(
-                decider_context=self.minimal_decider_context,
+                decider_context=self.dc,
                 config_watcher=filewatcher,
                 server_span=self.mock_span,
                 context_name="test",
@@ -1305,7 +1314,7 @@ class TestDeciderGetVariantAndExpose(unittest.TestCase):
             filewatcher = FileWatcher(path=f.name, parser=init_decider_parser, timeout=2, backoff=2)
 
             decider = Decider(
-                decider_context=self.minimal_decider_context,
+                decider_context=self.dc,
                 config_watcher=filewatcher,
                 server_span=self.mock_span,
                 context_name="test",
@@ -1355,7 +1364,7 @@ class TestDeciderGetVariantAndExpose(unittest.TestCase):
             filewatcher = FileWatcher(path=f.name, parser=init_decider_parser, timeout=2, backoff=2)
 
             decider = Decider(
-                decider_context=self.minimal_decider_context,
+                decider_context=self.dc,
                 config_watcher=filewatcher,
                 server_span=self.mock_span,
                 context_name="test",


### PR DESCRIPTION
Rust decider filters out all experiments whose `bucket_val` doesn't match the `identifier_type` param, which is now passed into `choose()`/`choose_all()` in the `get_..._for_identifier_...()` apis.

Therefore, we don't need to clear identifiers in context via `_clear_ctx_identifiers_and_set()` anymore to avoid bucketing an experiment with a mismatched `identifier_type`/`bucket_val`, since we'll only bucket the experiments with matching `identifier_type`.

This eliminates the possibility of overrides forcing a bucketing on experiments with mismatched `identifier_type`/`bucket_val` (e.g. a `device_id` experiment may return a result due to an `override` while only `identifier_type="canonical_url"` was requested).

This will also reduce error info logger lines in the sdk such as:
```
INFO     Encountered error for experiment: ae_trueblock_user_about in decider.choose_all(): Missing "user_id" in context for bucket_val = "user_id"
```
when there's a mismatched `identifier_type`/`bucket_val`.
Before filtering by `identifier_type` in rust was introduced, all experiments got bucketed and error logs were emitted due to mismatches (and errored experiments were removed in the sdk).