### PR TITLE
Add `typing_extensions` module to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ reorder-python-imports==2.3.6
 Sphinx==3.4.0
 sphinx-autodoc-typehints==1.11.1
 reddit-edgecontext==1.0.0a3
+typing_extensions==4.2.0


### PR DESCRIPTION
A service is experiencing:
```
ModuleNotFoundError: No module named 'typing_extensions'
```

This should fix it.