### PR TITLE
Upgrade `gevent` due to CI error

### DIFF
--- a/requirements-transitive.txt
+++ b/requirements-transitive.txt
@@ -8,7 +8,7 @@ chardet==4.0.0
 click==7.1.2
 coverage==5.3.1
 docutils==0.16
-gevent==20.12.0
+gevent==21.12.0
 greenlet==1.1.1
 idna==2.10
 imagesize==1.2.0


### PR DESCRIPTION
Getting a [package install failure](https://github.com/gevent/gevent/issues/1801) in py 3.10 CI for `develop` all of a sudden (worked fine on PR).

upgrading `gevent` to see if it resolves.