### PR TITLE
Update `auth_client_id` to be `oauth_client_id`

### DIFF
--- a/reddit_decider/__init__.py
+++ b/reddit_decider/__init__.py
@@ -61,7 +61,7 @@ class DeciderContext:
         user_is_employee: Optional[bool] = None,
         logged_in: Optional[bool] = None,
         device_id: Optional[str] = None,
-        auth_client_id: Optional[str] = None,
+        oauth_client_id: Optional[str] = None,
         origin_service: Optional[str] = None,
         cookie_created_timestamp: Optional[float] = None,
         extracted_fields: Optional[dict] = None,
@@ -72,7 +72,7 @@ class DeciderContext:
         self._user_is_employee = user_is_employee
         self._logged_in = logged_in
         self._device_id = device_id
-        self._auth_client_id = auth_client_id
+        self._oauth_client_id = oauth_client_id
         self._origin_service = origin_service
         self._cookie_created_timestamp = cookie_created_timestamp
         self._extracted_fields = extracted_fields
@@ -87,7 +87,7 @@ class DeciderContext:
             "user_is_employee": self._user_is_employee,
             "logged_in": self._logged_in,
             "device_id": self._device_id,
-            "auth_client_id": self._auth_client_id,
+            "oauth_client_id": self._oauth_client_id,
             "origin_service": self._origin_service,
             "cookie_created_timestamp": self._cookie_created_timestamp,
             "other_fields": ef,
@@ -1042,12 +1042,12 @@ class DeciderContextFactory(ContextFactory):
                 f"Error while accessing `user.event_fields()` in `make_object_for_context()`. details: {exc}"
             )
 
-        auth_client_id = None
+        oauth_client_id = None
         try:
             if isinstance(ec.authentication_token, ValidatedAuthenticationToken):
                 oc_id = ec.authentication_token.oauth_client_id
                 if oc_id:
-                    auth_client_id = oc_id
+                    oauth_client_id = oc_id
         except Exception as exc:
             logger.info(
                 f"Unable to access `ec.authentication_token.oauth_client_id` in `make_object_for_context()`. details: {exc}"
@@ -1102,7 +1102,7 @@ class DeciderContextFactory(ContextFactory):
                 origin_service=origin_service,
                 user_is_employee=is_employee,
                 device_id=device_id,
-                auth_client_id=auth_client_id,
+                oauth_client_id=oauth_client_id,
                 cookie_created_timestamp=cookie_created_timestamp,
                 extracted_fields=parsed_extracted_fields,
             )

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 alabaster==0.7.12
 baseplate==2.0.0a1
 black==21.4b2
-reddit-decider==1.2.2
+reddit-decider==1.2.15
 flake8==3.9.1
 mypy==0.790
 pyramid==2.0   # required for `from baseplate.frameworks.pyramid import BaseplateRequest` which calls `import pyramid.events`

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     install_requires=[
         "baseplate>=2.0.0a1,<3.0",
         "reddit-edgecontext>=1.0.0a3,<2.0",
-        "reddit-decider>=1.2.2",
+        "reddit-decider>=1.2.15",
         "typing_extensions>=3.10.0.0",
     ],
     package_data={"reddit_experiments": ["py.typed"]},

--- a/tests/decider_tests.py
+++ b/tests/decider_tests.py
@@ -149,7 +149,7 @@ class DeciderContextFactoryTests(unittest.TestCase):
         self.assertEqual(decider_ctx_dict["device_id"], DEVICE_ID)
         self.assertEqual(decider_ctx_dict["locale"], LOCALE_CODE)
         self.assertEqual(decider_ctx_dict["origin_service"], ORIGIN_SERVICE)
-        self.assertEqual(decider_ctx_dict["auth_client_id"], AUTH_CLIENT_ID)
+        self.assertEqual(decider_ctx_dict["oauth_client_id"], AUTH_CLIENT_ID)
         self.assertEqual(
             decider_ctx_dict["cookie_created_timestamp"],
             self.mock_span.context.edge_context.user.event_fields().get("cookie_created_timestamp"),
@@ -178,7 +178,7 @@ class DeciderContextFactoryTests(unittest.TestCase):
         self.assertEqual(decider_event_dict["locale"], LOCALE_CODE)
         self.assertEqual(decider_event_dict["app"]["relevant_locale"], LOCALE_CODE)
         self.assertEqual(decider_event_dict["origin_service"], ORIGIN_SERVICE)
-        self.assertEqual(decider_event_dict.get("auth_client_id"), None)
+        self.assertEqual(decider_event_dict.get("oauth_client_id"), None)
         self.assertEqual(
             decider_event_dict["cookie_created_timestamp"],
             self.mock_span.context.edge_context.user.event_fields().get("cookie_created_timestamp"),
@@ -373,7 +373,7 @@ class TestDeciderGetVariantAndExpose(unittest.TestCase):
             origin_service=ORIGIN_SERVICE,
             user_is_employee=True,
             device_id=DEVICE_ID,
-            auth_client_id=AUTH_CLIENT_ID,
+            oauth_client_id=AUTH_CLIENT_ID,
             cookie_created_timestamp=COOKIE_CREATED_TIMESTAMP,
             extracted_fields=decider_field_extractor(_request=None),
         )
@@ -649,7 +649,7 @@ class TestDeciderGetVariantAndExpose(unittest.TestCase):
                 self.assertEqual(self.event_logger.log.call_count, 0)
 
                 assert any(
-                    'Requested identifier_type: "canonical_url" is incompatible with experiment\'s "bucket_val" = "device_id".'
+                    'Requested identifier_type: "canonical_url" is incompatible with experiment\'s bucket_val = device_id.'
                     in x.getMessage()
                     for x in captured.records
                 )
@@ -758,7 +758,7 @@ class TestDeciderGetVariantAndExpose(unittest.TestCase):
                 self.assertEqual(variant, None)
 
                 assert any(
-                    'Encountered error in decider.choose(): Requested identifier_type: "canonical_url" is incompatible with experiment\'s "bucket_val" = "device_id".'
+                    'Encountered error in decider.choose(): Requested identifier_type: "canonical_url" is incompatible with experiment\'s bucket_val = device_id.'
                     in x.getMessage()
                     for x in captured.records
                 )
@@ -1288,7 +1288,7 @@ class TestDeciderGetDynamicConfig(unittest.TestCase):
             origin_service=ORIGIN_SERVICE,
             user_is_employee=True,
             device_id=DEVICE_ID,
-            auth_client_id=AUTH_CLIENT_ID,
+            oauth_client_id=AUTH_CLIENT_ID,
             cookie_created_timestamp=COOKIE_CREATED_TIMESTAMP,
         )
 


### PR DESCRIPTION
I dropped the prefixed "o" in oauth_client_id when I was implementing this field for some reason and am now adding it back for consistency with [EdgeContext field name](https://github.com/reddit/edgecontext/blob/b59fc1742b473d6b075b464457dd2836988e732a/lib/py/reddit_edgecontext/__init__.py#L134-L135).