### PR TITLE
Add loid created timestamp

### DIFF
--- a/reddit_decider/__init__.py
+++ b/reddit_decider/__init__.py
@@ -64,6 +64,7 @@ class DeciderContext:
         oauth_client_id: Optional[str] = None,
         origin_service: Optional[str] = None,
         cookie_created_timestamp: Optional[float] = None,
+        loid_created_timestamp: Optional[float] = None,
         extracted_fields: Optional[dict] = None,
     ):
         self._user_id = user_id
@@ -75,6 +76,7 @@ class DeciderContext:
         self._oauth_client_id = oauth_client_id
         self._origin_service = origin_service
         self._cookie_created_timestamp = cookie_created_timestamp
+        self._loid_created_timestamp = loid_created_timestamp
         self._extracted_fields = extracted_fields
 
     def to_dict(self) -> Dict:
@@ -90,6 +92,7 @@ class DeciderContext:
             "oauth_client_id": self._oauth_client_id,
             "origin_service": self._origin_service,
             "cookie_created_timestamp": self._cookie_created_timestamp,
+            "loid_created_timestamp": self._loid_created_timestamp,
             "other_fields": ef,
             **ef,
         }
@@ -99,6 +102,7 @@ class DeciderContext:
             "id": self._user_id,
             "logged_in": self._logged_in,
             "cookie_created_timestamp": self._cookie_created_timestamp,
+            "loid_created_timstamp": self._loid_created_timestamp,
             "is_employee": self._user_is_employee,
         }
 
@@ -135,6 +139,7 @@ class DeciderContext:
             "device_id": self._device_id,
             "origin_service": self._origin_service,
             "cookie_created_timestamp": self._cookie_created_timestamp,
+            "loid_created_timestamp": self._loid_created_timestamp,
             "user": user_fields,
             "app": app_fields,
             "geo": geo_fields,
@@ -1041,6 +1046,17 @@ class DeciderContextFactory(ContextFactory):
             logger.info(
                 f"Error while accessing `user.event_fields()` in `make_object_for_context()`. details: {exc}"
             )
+        
+        loid_created_timestamp = None
+        try:
+            if isinstance(ec.authentication_token, ValidatedAuthenticationToken):
+                loid_cms = ec.authentication_token.oauth_client_id
+                if oc_id:
+                    loid_created_timestamp = loid_cms
+        except Exception as exc:
+            logger.info(
+                f"Unable to access `ec.authentication_token.loid_created_ms` in `make_object_for_context()`. details: {exc}"
+            )
 
         oauth_client_id = None
         try:
@@ -1104,6 +1120,7 @@ class DeciderContextFactory(ContextFactory):
                 device_id=device_id,
                 oauth_client_id=oauth_client_id,
                 cookie_created_timestamp=cookie_created_timestamp,
+                loid_created_timestamp=loid_created_timestamp,
                 extracted_fields=parsed_extracted_fields,
             )
         except Exception as exc:

--- a/reddit_decider/__init__.py
+++ b/reddit_decider/__init__.py
@@ -1046,7 +1046,7 @@ class DeciderContextFactory(ContextFactory):
             logger.info(
                 f"Error while accessing `user.event_fields()` in `make_object_for_context()`. details: {exc}"
             )
-        
+
         loid_created_timestamp = None
         try:
             if isinstance(ec.authentication_token, ValidatedAuthenticationToken):

--- a/reddit_decider/__init__.py
+++ b/reddit_decider/__init__.py
@@ -1050,8 +1050,8 @@ class DeciderContextFactory(ContextFactory):
         loid_created_timestamp = None
         try:
             if isinstance(ec.authentication_token, ValidatedAuthenticationToken):
-                loid_cms = ec.authentication_token.oauth_client_id
-                if oc_id:
+                loid_cms = ec.authentication_token.loid_created_ms
+                if loid_cms:
                     loid_created_timestamp = loid_cms
         except Exception as exc:
             logger.info(

--- a/reddit_decider/__init__.py
+++ b/reddit_decider/__init__.py
@@ -102,7 +102,6 @@ class DeciderContext:
             "id": self._user_id,
             "logged_in": self._logged_in,
             "cookie_created_timestamp": self._cookie_created_timestamp,
-            "loid_created_timstamp": self._loid_created_timestamp,
             "is_employee": self._user_is_employee,
         }
 
@@ -139,7 +138,6 @@ class DeciderContext:
             "device_id": self._device_id,
             "origin_service": self._origin_service,
             "cookie_created_timestamp": self._cookie_created_timestamp,
-            "loid_created_timestamp": self._loid_created_timestamp,
             "user": user_fields,
             "app": app_fields,
             "geo": geo_fields,

--- a/tests/decider_tests.py
+++ b/tests/decider_tests.py
@@ -27,6 +27,7 @@ AUTH_CLIENT_ID = "token"
 COUNTRY_CODE = "US"
 DEVICE_ID = "abc"
 COOKIE_CREATED_TIMESTAMP = 1234
+LOID_CREATED_TIMESTAMP = 123456
 LOCALE_CODE = "us_en"
 ORIGIN_SERVICE = "origin"
 APP_NAME = "ios"
@@ -115,6 +116,7 @@ class DeciderContextFactoryTests(unittest.TestCase):
             spec=ValidatedAuthenticationToken
         )
         self.mock_span.context.edge_context.authentication_token.oauth_client_id = AUTH_CLIENT_ID
+        self.mock_span.context.edge_context.authentication_token.loid_created_ms = LOID_CREATED_TIMESTAMP
         self.mock_span.context.edge_context.geolocation.country_code = COUNTRY_CODE
         self.mock_span.context.edge_context.locale.locale_code = LOCALE_CODE
         self.mock_span.context.edge_context.origin_service.name = ORIGIN_SERVICE
@@ -154,6 +156,7 @@ class DeciderContextFactoryTests(unittest.TestCase):
             decider_ctx_dict["cookie_created_timestamp"],
             self.mock_span.context.edge_context.user.event_fields().get("cookie_created_timestamp"),
         )
+        self.assertEqual(decider_ctx_dict["loid_created_timestamp"], LOID_CREATED_TIMESTAMP)
         self.assertEqual(decider_ctx_dict["app_name"], APP_NAME)
         self.assertEqual(decider_ctx_dict["other_fields"]["app_name"], APP_NAME)
         self.assertEqual(decider_ctx_dict["app_version"], APP_VERSION)
@@ -179,6 +182,7 @@ class DeciderContextFactoryTests(unittest.TestCase):
         self.assertEqual(decider_event_dict["app"]["relevant_locale"], LOCALE_CODE)
         self.assertEqual(decider_event_dict["origin_service"], ORIGIN_SERVICE)
         self.assertEqual(decider_event_dict.get("oauth_client_id"), None)
+        self.assertEqual(decider_event_dict["loid_created_timestamp"], LOID_CREATED_TIMESTAMP)
         self.assertEqual(
             decider_event_dict["cookie_created_timestamp"],
             self.mock_span.context.edge_context.user.event_fields().get("cookie_created_timestamp"),
@@ -375,6 +379,7 @@ class TestDeciderGetVariantAndExpose(unittest.TestCase):
             device_id=DEVICE_ID,
             oauth_client_id=AUTH_CLIENT_ID,
             cookie_created_timestamp=COOKIE_CREATED_TIMESTAMP,
+            loid_created_timestamp=LOID_CREATED_TIMESTAMP,
             extracted_fields=decider_field_extractor(_request=None),
         )
 
@@ -1290,6 +1295,7 @@ class TestDeciderGetDynamicConfig(unittest.TestCase):
             device_id=DEVICE_ID,
             oauth_client_id=AUTH_CLIENT_ID,
             cookie_created_timestamp=COOKIE_CREATED_TIMESTAMP,
+            loid_created_timestamp=LOID_CREATED_TIMESTAMP,
         )
 
     def setup_decider(self, file_name, decider_context):

--- a/tests/decider_tests.py
+++ b/tests/decider_tests.py
@@ -184,7 +184,6 @@ class DeciderContextFactoryTests(unittest.TestCase):
         self.assertEqual(decider_event_dict["app"]["relevant_locale"], LOCALE_CODE)
         self.assertEqual(decider_event_dict["origin_service"], ORIGIN_SERVICE)
         self.assertEqual(decider_event_dict.get("oauth_client_id"), None)
-        self.assertEqual(decider_event_dict["loid_created_timestamp"], LOID_CREATED_TIMESTAMP)
         self.assertEqual(
             decider_event_dict["cookie_created_timestamp"],
             self.mock_span.context.edge_context.user.event_fields().get("cookie_created_timestamp"),

--- a/tests/decider_tests.py
+++ b/tests/decider_tests.py
@@ -116,7 +116,9 @@ class DeciderContextFactoryTests(unittest.TestCase):
             spec=ValidatedAuthenticationToken
         )
         self.mock_span.context.edge_context.authentication_token.oauth_client_id = AUTH_CLIENT_ID
-        self.mock_span.context.edge_context.authentication_token.loid_created_ms = LOID_CREATED_TIMESTAMP
+        self.mock_span.context.edge_context.authentication_token.loid_created_ms = (
+            LOID_CREATED_TIMESTAMP
+        )
         self.mock_span.context.edge_context.geolocation.country_code = COUNTRY_CODE
         self.mock_span.context.edge_context.locale.locale_code = LOCALE_CODE
         self.mock_span.context.edge_context.origin_service.name = ORIGIN_SERVICE


### PR DESCRIPTION
## 💸 TL;DR
This PR passes `loid_created_ms` from the edge context to the decider as `loid_created_timestamp`

This corresponding PR adds `loid_created_timestamp` into the decider context.