### PR TITLE
Read the Docs minimal requirements

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,4 @@
+docutils==0.16
+pydocstyle==5.1.1
+Sphinx==3.4.0
+sphinx-autodoc-typehints==1.11.1


### PR DESCRIPTION
docs aren't being updated because [builds are failing](https://readthedocs.org/projects/reddit-experiments/builds/17812984/) due to rust dependency.

https://docs.readthedocs.io/en/stable/tutorial/index.html#preparing-your-project-on-github says `docs/requirements.txt` can get parsed so I'm hoping the build will use this minimal requirements set instead of the full one including rust.

