### PR TITLE
Add jinja & alabaster to docs/requirements.txt

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,6 @@
+alabaster==0.7.12
 docutils==0.16
+Jinja2==2.11.2
 pydocstyle==5.1.1
 Sphinx==3.4.0
 sphinx-autodoc-typehints==1.11.1


### PR DESCRIPTION
`ImportError: cannot import name 'environmentfilter' from 'jinja2'` [build failure](https://readthedocs.org/projects/reddit-experiments/builds/17815270/)
and `alabaster` is also referenced in [docs/conf.py](https://github.com/reddit/experiments.py/blob/556faeebe6ca62c94971d139e941657d3a7cb149/docs/conf.py#L8)