### PR TITLE
Move around docs requirements

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,13 @@
 alabaster==0.7.12
 docutils==0.16
 Jinja2==2.11.2
+MarkupSafe==1.1.1
 pydocstyle==5.1.1
 Sphinx==3.4.0
 sphinx-autodoc-typehints==1.11.1
+sphinxcontrib-applehelp==1.0.2
+sphinxcontrib-devhelp==1.0.2
+sphinxcontrib-htmlhelp==1.0.3
+sphinxcontrib-jsmath==1.0.1
+sphinxcontrib-qthelp==1.0.3
+sphinxcontrib-serializinghtml==1.1.4

--- a/requirements-transitive.txt
+++ b/requirements-transitive.txt
@@ -7,7 +7,6 @@ certifi==2020.12.5
 chardet==4.0.0
 click==7.1.2
 coverage==5.3.1
-docutils==0.16
 gevent==21.12.0
 greenlet==1.1.1
 idna==2.10
@@ -33,12 +32,6 @@ regex==2020.11.13
 requests==2.25.1
 six==1.15.0
 snowballstemmer==2.0.0
-sphinxcontrib-applehelp==1.0.2
-sphinxcontrib-devhelp==1.0.2
-sphinxcontrib-htmlhelp==1.0.3
-sphinxcontrib-jsmath==1.0.1
-sphinxcontrib-qthelp==1.0.3
-sphinxcontrib-serializinghtml==1.1.4
 thrift==0.13.0
 toml==0.10.2
 typed-ast==1.4.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 -r requirements-transitive.txt
-alabaster==0.7.12
 baseplate==2.0.0a1
 black==21.4b2
 reddit-decider==1.2.15
@@ -10,7 +9,5 @@ pydocstyle==5.1.1
 pytest==6.2.5
 pytest-cov==2.10.1
 reorder-python-imports==2.3.6
-Sphinx==3.4.0
-sphinx-autodoc-typehints==1.11.1
 reddit-edgecontext==1.0.0a3
 typing_extensions==4.2.0


### PR DESCRIPTION
`ImportError: cannot import name 'soft_unicode' from 'markupsafe'`
doc [build failed](https://readthedocs.org/projects/reddit-experiments/builds/17815335/)

This should also make our package a bit more lightweight.