### PR TITLE
Include rust + reddit-decider package

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,26 @@
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the version of Python and other tools you might need
+build:
+  os: ubuntu-20.04
+  tools:
+    python: "3.7"
+    rust: "1.59"
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+   configuration: docs/conf.py
+
+# If using Sphinx, optionally build your docs in additional formats such as PDF
+# formats:
+#    - pdf
+
+# Optionally declare the Python requirements required to build your docs
+python:
+   install:
+   - requirements: docs/requirements.txt

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -3,6 +3,7 @@ docutils==0.16
 Jinja2==2.11.2
 MarkupSafe==1.1.1
 pydocstyle==5.1.1
+reddit-decider==1.2.15
 Sphinx==3.4.0
 sphinx-autodoc-typehints==1.11.1
 sphinxcontrib-applehelp==1.0.2


### PR DESCRIPTION
Not able to see autodoc classes/functions (e.g. [these](https://reddit-experiments.readthedocs.io/en/latest/#configuration-classes)) due to:
```
WARNING: autodoc: failed to import module 'reddit_decider'; the following exception was raised:
No module named 'rust_decider'
```
https://readthedocs.org/projects/reddit-experiments/builds/17823824/

Hoping this may resolve the issue.