### PR TITLE
Bump min decider version & lock down typing_extensions package version

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -59,7 +59,7 @@ Upgrade or integrate reddit-experiments package:
 .. code-block:: python
 
     # import latest reddit-experiments package in service requirements.txt
-    reddit-experiments>=1.3.8
+    reddit-experiments>=1.3.9
 
 Initialize :code:`decider` instance on Baseplate context
 --------------------------------------------------------
@@ -117,7 +117,7 @@ Make sure :code:`EdgeContext` is accessible on :code:`request` object like so:
     #   - locale
     #   - origin_service
     #   - is_employee
-    #   - loid_created_ms (>=1.3.8)
+    #   - loid_created_ms (>=1.3.9)
 
     # Customized fields can be defined below to be extracted from a baseplate request
     # and will override above edge_context fields.

--- a/setup.py
+++ b/setup.py
@@ -19,8 +19,8 @@ setup(
     install_requires=[
         "baseplate>=2.0.0a1,<3.0",
         "reddit-edgecontext>=1.0.0a3,<2.0",
-        "reddit-decider>=1.2.15",
-        "typing_extensions>=3.10.0.0",
+        "reddit-decider>=1.2.18,<2.0",
+        "typing_extensions>=3.10.0.0,<5.0",
     ],
     package_data={"reddit_experiments": ["py.typed"]},
     zip_safe=True,


### PR DESCRIPTION
I realized we forgot to bump the min required version of `reddit-decider` ([1.2.18](https://github.snooguts.net/reddit/decider/commit/608ac16960580779362c7e244b71895b5674b71b)) necessary for `loid_created_timestamp` targeting to function. 
I believe pip installs the latest available version of decider, e.g.:
```
reddit-decider>=1.2.15 in .../Python/3.8/lib/python/site-packages (from reddit-experiments==1.3.8) (1.2.18)
```
but I want to solidify the requirement (in unlikely scenario that someone pins down `reddit-decider` below 1.2.18) and also add a top-bound to not automatically upgrade `reddit-decider` to 2.0 and beyond.

Similarly, I added a top-bound of 5.0 on `typing_extensions` package. I believe it's already pulling 4.x versions in prod since we haven't had a top-bound so far, e.g.:
```
typing-extensions>=3.10.0.0 in .../Python/3.8/lib/python/site-packages (from reddit-experiments==1.3.8) (4.3.0)
```
so I'm not going to force those to revert down to 3.10 since there seems to not be any issues with 4.x so far.

