### PR TITLE
Lockdown `reddit-decider` package version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     install_requires=[
         "baseplate>=2.0.0a1,<3.0",
         "reddit-edgecontext>=1.0.0a3,<2.0",
-        "reddit-decider>=1.2.18,<2.0",
+        "reddit-decider==1.2.23",
         "typing_extensions>=3.10.0.0,<5.0",
     ],
     package_data={"reddit_experiments": ["py.typed"]},

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     install_requires=[
         "baseplate>=2.0.0a1,<3.0",
         "reddit-edgecontext>=1.0.0a3,<2.0",
-        "reddit-decider==1.2.23",
+        "reddit-decider~=1.2.23",
         "typing_extensions>=3.10.0.0,<5.0",
     ],
     package_data={"reddit_experiments": ["py.typed"]},


### PR DESCRIPTION
Locking down the version of reddit-decider package to [1.2.23](https://github.snooguts.net/reddit/decider/releases/tag/1.2.23) to avoid pulling latest decider lib upon pip install of `reddit-experiments` when deploying.
