### PR TITLE
Use `rust_decider.RustDecider` in `get_variant()` & `get_variant_without_expose()`

### DIFF
--- a/reddit_decider/__init__.py
+++ b/reddit_decider/__init__.py
@@ -25,7 +25,6 @@ from reddit_edgecontext import ValidatedAuthenticationToken
 from rust_decider import Decider as RustDecider
 from rust_decider import DeciderException
 from rust_decider import FeatureNotFoundException
-from rust_decider import DeciderInitException
 from rust_decider import make_ctx
 from typing_extensions import Literal
 

--- a/reddit_decider/__init__.py
+++ b/reddit_decider/__init__.py
@@ -13,6 +13,8 @@ from typing import Union
 
 import rust_decider  # type: ignore
 from rust_decider import Decider as RustDecider
+from rust_decider import DeciderInitError
+from rust_decider import DeciderError
 
 from baseplate import RequestContext
 from baseplate import Span
@@ -344,7 +346,7 @@ class Decider:
 
         try:
             decision = self._rs_decider.choose(experiment_name, ctx)
-        except ValueError as exc:
+        except DeciderError as exc:
             logger.info(exc)
             return None
 
@@ -386,7 +388,7 @@ class Decider:
 
         try:
             decision = self._rs_decider.choose(experiment_name, ctx)
-        except ValueError as exc:
+        except DeciderError as exc:
             logger.info(exc)
             return None
 
@@ -1025,7 +1027,7 @@ class DeciderContextFactory(ContextFactory):
             rs_decider = self._filewatcher.get_data()
         except WatchedFileNotAvailableError as exc:
             logger.error(f"Experiment config file unavailable: {exc}")
-        except Exception as exc:
+        except DeciderInitError as exc:
             logger.error(f"Could not load experiment config: {exc}")
 
         if span is None:

--- a/reddit_decider/__init__.py
+++ b/reddit_decider/__init__.py
@@ -13,8 +13,8 @@ from typing import Union
 
 import rust_decider  # type: ignore
 from rust_decider import Decider as RustDecider
-from rust_decider import DeciderInitError
-from rust_decider import DeciderError
+from rust_decider import DeciderInitException
+from rust_decider import DeciderException
 
 from baseplate import RequestContext
 from baseplate import Span
@@ -346,7 +346,7 @@ class Decider:
 
         try:
             decision = self._rs_decider.choose(experiment_name, ctx)
-        except DeciderError as exc:
+        except DeciderException as exc:
             logger.info(exc)
             return None
 
@@ -381,7 +381,7 @@ class Decider:
 
         try:
             decision = self._rs_decider.choose(experiment_name, ctx)
-        except DeciderError as exc:
+        except DeciderException as exc:
             logger.info(exc)
             return None
 
@@ -1013,7 +1013,7 @@ class DeciderContextFactory(ContextFactory):
             rs_decider = self._filewatcher.get_data()
         except WatchedFileNotAvailableError as exc:
             logger.error(f"Experiment config file unavailable: {exc}")
-        except DeciderInitError as exc:
+        except DeciderInitException as exc:
             logger.error(f"Could not load experiment config: {exc}")
 
         if span is None:

--- a/reddit_decider/__init__.py
+++ b/reddit_decider/__init__.py
@@ -350,20 +350,13 @@ class Decider:
             logger.info(exc)
             return None
 
-        if decision:
-            event_context_fields = self._decider_context.to_event_dict()
-            event_context_fields.update(exposure_kwargs or {})
+        event_context_fields = self._decider_context.to_event_dict()
+        event_context_fields.update(exposure_kwargs or {})
 
-            for event in decision.get("events", []):
-                self._send_expose(event=event, exposure_fields=event_context_fields)
+        for event in decision.events:
+            self._send_expose(event=event, exposure_fields=event_context_fields)
 
-            try:
-                return decision["variant"]
-            except KeyError:
-                logger.error("Field 'variant' not found in choose() return value")
-                return None
-
-        return None
+        return decision.variant
 
     def get_variant_without_expose(self, experiment_name: str) -> Optional[str]:
         """Return a bucketing variant, if any, without emitting exposure event.
@@ -392,19 +385,12 @@ class Decider:
             logger.info(exc)
             return None
 
-        if decision:
-            event_context_fields = self._decider_context.to_event_dict()
+        event_context_fields = self._decider_context.to_event_dict()
 
-            for event in decision.get("events", []):
-                self._send_expose_if_holdout(event=event, exposure_fields=event_context_fields)
+        for event in decision.events:
+            self._send_expose_if_holdout(event=event, exposure_fields=event_context_fields)
 
-            try:
-                return decision["variant"]
-            except KeyError:
-                logger.error("Field 'variant' not found in choose() return value")
-                return None
-
-        return None
+        return decision.variant
 
     def expose(
         self, experiment_name: str, variant_name: str, **exposure_kwargs: Optional[Dict[str, Any]]

--- a/reddit_decider/__init__.py
+++ b/reddit_decider/__init__.py
@@ -348,17 +348,20 @@ class Decider:
             logger.info(exc)
             return None
 
-        event_context_fields = self._decider_context.to_event_dict()
-        event_context_fields.update(exposure_kwargs or {})
+        if decision is not None:
+            event_context_fields = self._decider_context.to_event_dict()
+            event_context_fields.update(exposure_kwargs or {})
 
-        for event in decision.get("events", []):
-            self._send_expose(event=event, exposure_fields=event_context_fields)
+            for event in decision.get("events", []):
+                self._send_expose(event=event, exposure_fields=event_context_fields)
 
-        try:
-            return decision["variant"]
-        except KeyError:
-            logger.error("Field 'variant' not found in choose() return value")
-            return None
+            try:
+                return decision["variant"]
+            except KeyError:
+                logger.error("Field 'variant' not found in choose() return value")
+                return None
+
+        return None
 
     def get_variant_without_expose(self, experiment_name: str) -> Optional[str]:
         """Return a bucketing variant, if any, without emitting exposure event.

--- a/reddit_decider/__init__.py
+++ b/reddit_decider/__init__.py
@@ -1,4 +1,5 @@
 import logging
+import warnings
 
 from copy import deepcopy
 from dataclasses import dataclass
@@ -13,6 +14,7 @@ from typing import Union
 
 import rust_decider  # type: ignore
 from rust_decider import Decider as RustDecider
+from rust_decider import DeciderFeatureNotFoundException
 from rust_decider import DeciderInitException
 from rust_decider import DeciderException
 
@@ -346,6 +348,9 @@ class Decider:
 
         try:
             decision = self._rs_decider.choose(experiment_name, ctx)
+        except DeciderFeatureNotFoundException as exc:
+            warnings.warn(exc)
+            return None
         except DeciderException as exc:
             logger.info(exc)
             return None

--- a/reddit_decider/__init__.py
+++ b/reddit_decider/__init__.py
@@ -386,6 +386,9 @@ class Decider:
 
         try:
             decision = self._rs_decider.choose(experiment_name, ctx)
+        except DeciderFeatureNotFoundException as exc:
+            warnings.warn(exc)
+            return None
         except DeciderException as exc:
             logger.info(exc)
             return None

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 -r requirements-transitive.txt
 baseplate==2.0.0a1
 black==21.4b2
-reddit-decider==1.2.26
+reddit-decider==1.2.28
 flake8==3.9.1
 mypy==0.790
 pyramid==2.0   # required for `from baseplate.frameworks.pyramid import BaseplateRequest` which calls `import pyramid.events`

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 -r requirements-transitive.txt
 baseplate==2.0.0a1
 black==21.4b2
-reddit-decider==1.2.25
+reddit-decider==1.2.26
 flake8==3.9.1
 mypy==0.790
 pyramid==2.0   # required for `from baseplate.frameworks.pyramid import BaseplateRequest` which calls `import pyramid.events`

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 -r requirements-transitive.txt
 baseplate==2.0.0a1
 black==21.4b2
-reddit-decider==1.2.24
+reddit-decider==1.2.25
 flake8==3.9.1
 mypy==0.790
 pyramid==2.0   # required for `from baseplate.frameworks.pyramid import BaseplateRequest` which calls `import pyramid.events`

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,3 +24,8 @@ warn_unused_ignores = True
 warn_return_any = False
 no_implicit_reexport = True
 strict_equality = True
+
+[mypy-rust_decider]
+# TODO: add stubs to reddit-decider
+# see https://pyo3.rs/v0.16.2/python_typing_hints.html
+ignore_missing_imports = True

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     install_requires=[
         "baseplate>=2.0.0a1,<3.0",
         "reddit-edgecontext>=1.0.0a3,<2.0",
-        "reddit-decider~=1.2.24",
+        "reddit-decider~=1.2.25",
         "typing_extensions>=3.10.0.0,<5.0",
     ],
     package_data={"reddit_experiments": ["py.typed"]},

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     install_requires=[
         "baseplate>=2.0.0a1,<3.0",
         "reddit-edgecontext>=1.0.0a3,<2.0",
-        "reddit-decider~=1.2.25",
+        "reddit-decider~=1.2.26",
         "typing_extensions>=3.10.0.0,<5.0",
     ],
     package_data={"reddit_experiments": ["py.typed"]},

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     install_requires=[
         "baseplate>=2.0.0a1,<3.0",
         "reddit-edgecontext>=1.0.0a3,<2.0",
-        "reddit-decider~=1.2.26",
+        "reddit-decider~=1.2.28",
         "typing_extensions>=3.10.0.0,<5.0",
     ],
     package_data={"reddit_experiments": ["py.typed"]},

--- a/tests/decider_tests.py
+++ b/tests/decider_tests.py
@@ -496,7 +496,7 @@ class TestDeciderGetVariantAndExpose(unittest.TestCase):
                 self.assertEqual(self.event_logger.log.call_count, 0)
 
                 assert any(
-                    'rust_decider.init() has error: Decider initialization failed: Partially loaded decider: 1 features failed to load.'
+                    "rust_decider.init() has error: Decider initialization failed: Partially loaded decider: 1 features failed to load."
                     in x.getMessage()
                     for x in captured.records
                 )

--- a/tests/decider_tests.py
+++ b/tests/decider_tests.py
@@ -68,7 +68,7 @@ def setup_decider(file_name, decider_context, mock_span, event_logger):
 
     return Decider(
         decider_context=decider_context,
-        rs_decider=rs_decider,
+        internal=rs_decider,
         server_span=mock_span,
         context_name="test",
         event_logger=event_logger,
@@ -496,7 +496,7 @@ class TestDeciderGetVariantAndExpose(unittest.TestCase):
                 self.assertEqual(self.event_logger.log.call_count, 0)
 
                 assert any(
-                    'rust_decider.init() has error: Decider initialization failed: Json error: "invalid type: string \\"1\\", expected u32".'
+                    'rust_decider.init() has error: Decider initialization failed: Partially loaded decider: 1 features failed to load.'
                     in x.getMessage()
                     for x in captured.records
                 )
@@ -695,7 +695,7 @@ class TestDeciderGetVariantAndExpose(unittest.TestCase):
                 self.assertEqual(self.event_logger.log.call_count, 0)
 
                 assert any(
-                    'Requested identifier_type: "canonical_url" is incompatible with experiment\'s bucket_val = device_id.'
+                    'Encountered error in decider.choose(): Requested identifier_type "canonical_url" is incompatible with experiment\'s bucket_val = device_id'
                     in x.getMessage()
                     for x in captured.records
                 )
@@ -806,7 +806,7 @@ class TestDeciderGetVariantAndExpose(unittest.TestCase):
                 self.assertEqual(variant, None)
 
                 assert any(
-                    'Encountered error in decider.choose(): Requested identifier_type: "canonical_url" is incompatible with experiment\'s bucket_val = device_id.'
+                    'Encountered error in decider.choose(): Requested identifier_type "canonical_url" is incompatible with experiment\'s bucket_val = device_id'
                     in x.getMessage()
                     for x in captured.records
                 )

--- a/tests/decider_tests.py
+++ b/tests/decider_tests.py
@@ -63,7 +63,7 @@ def setup_decider(file_name, decider_context, mock_span, event_logger):
     try:
         rs_decider = init_decider_parser(file_name)
     except Exception as e:
-        logger.error(e)
+        print(e)
         rs_decider = None
 
     return Decider(
@@ -496,7 +496,7 @@ class TestDeciderGetVariantAndExpose(unittest.TestCase):
                 self.assertEqual(self.event_logger.log.call_count, 0)
 
                 assert any(
-                    "Partially loaded Decider: 1 features failed to load: {\'test\': \'invalid type: string \"1\", expected u32\'}"
+                    "Partially loaded Decider: 1 features failed to load: {'test': 'invalid type: string \"1\", expected u32'}"
                     in x.getMessage()
                     for x in captured.records
                 )
@@ -537,9 +537,7 @@ class TestDeciderGetVariantAndExpose(unittest.TestCase):
         self.exp_base_config.update(config)
 
         with create_temp_config_file(self.exp_base_config) as f:
-            decider = setup_decider(
-                f, self.dc, self.mock_span, self.event_logger
-            )
+            decider = setup_decider(f, self.dc, self.mock_span, self.event_logger)
 
             self.assertEqual(self.event_logger.log.call_count, 0)
 

--- a/tests/decider_tests.py
+++ b/tests/decider_tests.py
@@ -58,6 +58,7 @@ def decider_field_extractor(_request: RequestContext):
         "canonical_url": CANONICAL_URL,
     }
 
+
 def setup_decider(file_name, decider_context, mock_span, event_logger):
     try:
         rs_decider = init_decider_parser(file_name)
@@ -72,6 +73,7 @@ def setup_decider(file_name, decider_context, mock_span, event_logger):
         context_name="test",
         event_logger=event_logger,
     )
+
 
 def first_occurrence_of_key_in(array, dict_key, name):
     return next((v for v in array if v[dict_key] == name), None)
@@ -485,7 +487,9 @@ class TestDeciderGetVariantAndExpose(unittest.TestCase):
         }
         with create_temp_config_file(config) as f:
             with self.assertLogs() as captured:
-                decider = setup_decider(f, self.minimal_decider_context, self.mock_span, self.event_logger)
+                decider = setup_decider(
+                    f, self.minimal_decider_context, self.mock_span, self.event_logger
+                )
                 variant = decider.get_variant("test")
 
                 self.assertEqual(variant, None)
@@ -510,7 +514,9 @@ class TestDeciderGetVariantAndExpose(unittest.TestCase):
             }
         }
         with create_temp_config_file(config) as f:
-            decider = setup_decider(f, self.minimal_decider_context, self.mock_span, self.event_logger)
+            decider = setup_decider(
+                f, self.minimal_decider_context, self.mock_span, self.event_logger
+            )
 
             self.assertEqual(self.event_logger.log.call_count, 0)
             variant = decider.get_variant("test")
@@ -518,7 +524,9 @@ class TestDeciderGetVariantAndExpose(unittest.TestCase):
 
     def test_none_returned_on_get_variant_call_with_experiment_not_found(self):
         with create_temp_config_file({}) as f:
-            decider = setup_decider(f, self.minimal_decider_context, self.mock_span, self.event_logger)
+            decider = setup_decider(
+                f, self.minimal_decider_context, self.mock_span, self.event_logger
+            )
 
             self.assertEqual(self.event_logger.log.call_count, 0)
             with warnings.catch_warnings(record=True) as captured:
@@ -527,11 +535,7 @@ class TestDeciderGetVariantAndExpose(unittest.TestCase):
                 # can't test warning log only shows up only once if `decider.get_variant("anything")`
                 # is called again due to bug in `catch_warnings` contextmanager
                 # see https://github.com/python/cpython/issues/73858
-                assert any(
-                    'Feature "anything" not found.'
-                    in str(x.message)
-                    for x in captured
-                )
+                assert any('Feature "anything" not found.' in str(x.message) for x in captured)
             self.assertEqual(variant, None)
 
             # no exposures should be triggered
@@ -571,7 +575,9 @@ class TestDeciderGetVariantAndExpose(unittest.TestCase):
 
     def test_none_returned_on_get_variant_without_expose_call_with_experiment_not_found(self):
         with create_temp_config_file({}) as f:
-            decider = setup_decider(f, self.minimal_decider_context, self.mock_span, self.event_logger)
+            decider = setup_decider(
+                f, self.minimal_decider_context, self.mock_span, self.event_logger
+            )
 
             self.assertEqual(self.event_logger.log.call_count, 0)
             with warnings.catch_warnings(record=True) as captured:
@@ -580,11 +586,7 @@ class TestDeciderGetVariantAndExpose(unittest.TestCase):
                 # can't test warning log only shows up only once if `decider.get_variant("anything")`
                 # is called again due to bug in `catch_warnings` contextmanager
                 # see https://github.com/python/cpython/issues/73858
-                assert any(
-                    'Feature "anything" not found.'
-                    in str(x.message)
-                    for x in captured
-                )
+                assert any('Feature "anything" not found.' in str(x.message) for x in captured)
             self.assertEqual(variant, None)
 
             # no exposures should be triggered
@@ -703,7 +705,9 @@ class TestDeciderGetVariantAndExpose(unittest.TestCase):
         identifier_type = "blah"
 
         with create_temp_config_file(self.exp_base_config) as f:
-            decider = setup_decider(f, self.minimal_decider_context, self.mock_span, self.event_logger)
+            decider = setup_decider(
+                f, self.minimal_decider_context, self.mock_span, self.event_logger
+            )
 
             self.assertEqual(self.event_logger.log.call_count, 0)
             with self.assertLogs() as captured:
@@ -977,7 +981,9 @@ class TestDeciderGetVariantAndExpose(unittest.TestCase):
         self.exp_base_config["exp_1"]["experiment"].update({"bucket_val": "device_id"})
 
         with create_temp_config_file(self.exp_base_config) as f:
-            decider = setup_decider(f, self.minimal_decider_context, self.mock_span, self.event_logger)
+            decider = setup_decider(
+                f, self.minimal_decider_context, self.mock_span, self.event_logger
+            )
 
             self.assertEqual(self.event_logger.log.call_count, 0)
 

--- a/tests/decider_tests.py
+++ b/tests/decider_tests.py
@@ -462,7 +462,7 @@ class TestDeciderGetVariantAndExpose(unittest.TestCase):
                 experiment_name="exp_1", variant=variant, event_fields=event_fields
             )
 
-    def test_none_returned_on_variant_call_with_bad_id(self):
+    def test_none_returned_on_get_variant_call_with_bad_id(self):
         config = {
             "test": {
                 "id": "1",
@@ -496,7 +496,7 @@ class TestDeciderGetVariantAndExpose(unittest.TestCase):
                 self.assertEqual(self.event_logger.log.call_count, 0)
 
                 assert any(
-                    "rust_decider.init() has error: Decider initialization failed: Partially loaded decider: 1 features failed to load."
+                    "Partially loaded Decider: 1 features failed to load: {\'test\': \'invalid type: string \"1\", expected u32\'}"
                     in x.getMessage()
                     for x in captured.records
                 )
@@ -521,6 +521,41 @@ class TestDeciderGetVariantAndExpose(unittest.TestCase):
             self.assertEqual(self.event_logger.log.call_count, 0)
             variant = decider.get_variant("test")
             self.assertEqual(variant, None)
+
+    def test_get_variant_calls_with_partial_data(self):
+        config = {
+            "test": {
+                "id": 1,
+                "name": "test",
+                "owner": "test_owner",
+                "type": "dynamic_config",
+                "version": "1",
+                "start_ts": 0,
+                "stop_ts": 0,
+            }
+        }
+        self.exp_base_config.update(config)
+
+        with create_temp_config_file(self.exp_base_config) as f:
+            decider = setup_decider(
+                f, self.dc, self.mock_span, self.event_logger
+            )
+
+            self.assertEqual(self.event_logger.log.call_count, 0)
+
+            # get_variant_for_identifier()
+            variant = decider.get_variant_for_identifier("test", USER_ID, "user_id")
+            self.assertEqual(variant, None)
+
+            variant = decider.get_variant_for_identifier("exp_1", USER_ID, "user_id")
+            self.assertEqual(variant, "variant_4")
+
+            # get_variant()
+            variant = decider.get_variant("test")
+            self.assertEqual(variant, None)
+
+            variant = decider.get_variant("exp_1")
+            self.assertEqual(variant, "variant_4")
 
     def test_none_returned_on_get_variant_call_with_experiment_not_found(self):
         with create_temp_config_file({}) as f:

--- a/tests/decider_tests.py
+++ b/tests/decider_tests.py
@@ -489,8 +489,7 @@ class TestDeciderGetVariantAndExpose(unittest.TestCase):
 
                 self.assertEqual(variant, None)
                 self.assertEqual(self.event_logger.log.call_count, 0)
-                print([x.getMessage()
-                for x in captured.records])
+
                 assert any(
                     'rust_decider.init() has error: Decider initialization failed: Json error: "invalid type: string \\"1\\", expected u32".'
                     in x.getMessage()
@@ -1551,7 +1550,6 @@ class TestDeciderGetDynamicConfig(unittest.TestCase):
         # missing "value_type" field
         experiments_cfg.update(missing_value_type_cfg)
 
-        print(experiments_cfg)
         with create_temp_config_file(experiments_cfg) as f:
             decider = setup_decider(f, self.dc, self.mock_span, self.event_logger)
 

--- a/tests/range_variant_tests/range_variant_parity_tests.py
+++ b/tests/range_variant_tests/range_variant_parity_tests.py
@@ -26,6 +26,7 @@ class TestExperiments(unittest.TestCase):
         with open(ORIGINAL_ZK_CONFIG_FILE, "r") as f:
             self.original_zk_config = json.load(f)
         with open(RANGE_VARIANT_ZK_CONFIG_FILE, "r") as f:
+            self.range_variant_zk_file = f
             self.range_variant_zk_config = json.load(f)
         self.mock_filewatcher = mock.Mock(spec=FileWatcher)
         self.mock_span = mock.MagicMock(spec=ServerSpan)
@@ -50,9 +51,7 @@ class TestExperiments(unittest.TestCase):
             cfg_data=self.range_variant_zk_config,
         )
 
-        filewatcher = FileWatcher(
-            path=RANGE_VARIANT_ZK_CONFIG_FILE, parser=init_decider_parser, timeout=2, backoff=2
-        )
+        rs_decider = init_decider_parser(self.range_variant_zk_file)
         extracted_fields = {"app_name": "", "build_number": 0}
 
         # results = {}
@@ -86,7 +85,7 @@ class TestExperiments(unittest.TestCase):
 
                 decider = Decider(
                     decider_context=decider_context,
-                    config_watcher=filewatcher,
+                    rs_decider=rs_decider,
                     server_span=self.mock_span,
                     context_name="test",
                     event_logger=self.event_logger,

--- a/tests/range_variant_tests/range_variant_parity_tests.py
+++ b/tests/range_variant_tests/range_variant_parity_tests.py
@@ -85,7 +85,7 @@ class TestExperiments(unittest.TestCase):
 
                 decider = Decider(
                     decider_context=decider_context,
-                    rs_decider=rs_decider,
+                    internal=rs_decider,
                     server_span=self.mock_span,
                     context_name="test",
                     event_logger=self.event_logger,


### PR DESCRIPTION
# Summary
This pr shows the updates required to incorporate the new decider python shims once they have been merged.
These changes have been tested locally but CI will not pass until the upstream [decider-py PR](https://github.snooguts.net/reddit/decider/pull/120) is merged & new `reddit-decider` package has been released.

## Changes
- `Decider()` constructor no longer takes a filewatcher param, since an instance of it should not update its experiment config json mid-request. 
Instead an instance of `rust_decider.RustDecider` class is passed in, which was initialized by the filewatcher in the `DeciderContextFactory`.
- Utilize `rust_decider.RustDecider#choose()`, instead of `rust_decider.make_ctx()`/`rust_decider.choose()` functions, in `get_variant()`/ `get_variant_without_expose()`
- only log `"Feature "{feature_name}" not found."` once via `warnings.warn()` to alleviate logs if the feature was disabled and not found in config (to maintain parity w/ [reddit_experiments](https://github.com/reddit/experiments.py/pull/2)) 