### PR TITLE
Return from `exposure()` if `variant_name` param not passed in

### DIFF
--- a/reddit_decider/__init__.py
+++ b/reddit_decider/__init__.py
@@ -388,14 +388,14 @@ class Decider:
             to :code:`events_logger` (keys must be part of v2 event schema,
             use dicts for nested fields) under :code:`inputs` and as :code:`kwargs`
         """
-        decider = self._get_decider()
-        if decider is None:
+        if variant_name is None or variant_name == "":
+            logger.info(
+                f"`variant_name` arg not provided in reddit_decider.expose() call for experiment: {experiment_name}"
+            )
             return
 
-        if variant_name is None or variant_name == "":
-            logger.warning(
-                f"`variant_name` not provided in expose() call for experiment: {experiment_name}"
-            )
+        decider = self._get_decider()
+        if decider is None:
             return
 
         experiment = decider.get_experiment(experiment_name)

--- a/reddit_decider/__init__.py
+++ b/reddit_decider/__init__.py
@@ -392,7 +392,7 @@ class Decider:
         if decider is None:
             return
 
-        if variant_name is None or variant_name is "":
+        if variant_name is None or variant_name == "":
             logger.warning(
                 f"`variant_name` not provided in expose() call for experiment: {experiment_name}"
             )

--- a/reddit_decider/__init__.py
+++ b/reddit_decider/__init__.py
@@ -392,6 +392,10 @@ class Decider:
         if decider is None:
             return
 
+        if variant_name is None or variant_name is "":
+            logger.warning(f"`variant_name` not provided in expose() call for experiment: {experiment_name}")
+            return
+
         experiment = decider.get_experiment(experiment_name)
         error = experiment.err()
         if error:

--- a/reddit_decider/__init__.py
+++ b/reddit_decider/__init__.py
@@ -865,12 +865,12 @@ class Decider:
         return parsed_configs
 
     def get_experiment(self, experiment_name: str) -> Optional[ExperimentConfig]:
-        """Get an :py:class:`~reddit_decider.ExperimentConfig` `dataclass <https://github.com/reddit/experiments.py/blob/728a9501faceab7072f9d62f4e391fa4c34a68b1/reddit_decider/__init__.py#L39-L47>`_
+        """Get an :py:class:`~reddit_decider.ExperimentConfig` `dataclass <https://github.com/reddit/experiments.py/blob/develop/reddit_decider/__init__.py#L44>`_
         representation of an experiment or :code:`None` if not found.
 
         :param experiment_name: Name of the experiment to be fetched.
 
-        :return: an :py:class:`~reddit_decider.ExperimentConfig` `dataclass <https://github.com/reddit/experiments.py/blob/728a9501faceab7072f9d62f4e391fa4c34a68b1/reddit_decider/__init__.py#L39-L47>`_
+        :return: an :py:class:`~reddit_decider.ExperimentConfig` `dataclass <https://github.com/reddit/experiments.py/blob/develop/reddit_decider/__init__.py#L44>`_
             representation of an experiment if found, else :code:`None`.
         """
         decider = self._get_decider()

--- a/reddit_decider/__init__.py
+++ b/reddit_decider/__init__.py
@@ -389,9 +389,6 @@ class Decider:
             use dicts for nested fields) under :code:`inputs` and as :code:`kwargs`
         """
         if variant_name is None or variant_name == "":
-            logger.info(
-                f"`variant_name` arg not provided in reddit_decider.expose() call for experiment: {experiment_name}"
-            )
             return
 
         decider = self._get_decider()

--- a/reddit_decider/__init__.py
+++ b/reddit_decider/__init__.py
@@ -393,7 +393,9 @@ class Decider:
             return
 
         if variant_name is None or variant_name is "":
-            logger.warning(f"`variant_name` not provided in expose() call for experiment: {experiment_name}")
+            logger.warning(
+                f"`variant_name` not provided in expose() call for experiment: {experiment_name}"
+            )
             return
 
         experiment = decider.get_experiment(experiment_name)

--- a/reddit_experiments/__init__.py
+++ b/reddit_experiments/__init__.py
@@ -301,6 +301,12 @@ class Experiments:
         :param kwargs: Additional arguments that will be passed to logger.
 
         """
+        if variant_name is None or variant_name == "":
+            logger.info(
+                f"`variant_name` arg not provided in reddit_experiments.expose() call for experiment: {experiment_name}"
+            )
+            return
+
         experiment = self._get_experiment(experiment_name)
 
         if experiment is None:

--- a/reddit_experiments/__init__.py
+++ b/reddit_experiments/__init__.py
@@ -302,9 +302,6 @@ class Experiments:
 
         """
         if variant_name is None or variant_name == "":
-            logger.info(
-                f"`variant_name` arg not provided in reddit_experiments.expose() call for experiment: {experiment_name}"
-            )
             return
 
         experiment = self._get_experiment(experiment_name)

--- a/tests/decider_tests.py
+++ b/tests/decider_tests.py
@@ -755,14 +755,7 @@ class TestDeciderGetVariantAndExpose(unittest.TestCase):
 
             self.assertEqual(self.event_logger.log.call_count, 0)
 
-            with self.assertLogs() as captured:
-                decider.expose("exp_1", None)
-
-                assert any(
-                    "`variant_name` arg not provided in reddit_decider.expose() call for experiment: exp_1"
-                    in x.getMessage()
-                    for x in captured.records
-                )
+            decider.expose("exp_1", None)
 
             # exposure assertions
             self.assertEqual(self.event_logger.log.call_count, 0)

--- a/tests/decider_tests.py
+++ b/tests/decider_tests.py
@@ -759,7 +759,7 @@ class TestDeciderGetVariantAndExpose(unittest.TestCase):
                 decider.expose("exp_1", None)
 
                 assert any(
-                    '`variant_name` not provided in expose() call for experiment: exp_1'
+                    "`variant_name` not provided in expose() call for experiment: exp_1"
                     in x.getMessage()
                     for x in captured.records
                 )

--- a/tests/decider_tests.py
+++ b/tests/decider_tests.py
@@ -754,12 +754,12 @@ class TestDeciderGetVariantAndExpose(unittest.TestCase):
             decider = self.setup_decider(f.name, self.dc)
 
             self.assertEqual(self.event_logger.log.call_count, 0)
-            variant = "variant_4"
+
             with self.assertLogs() as captured:
                 decider.expose("exp_1", None)
 
                 assert any(
-                    "`variant_name` not provided in expose() call for experiment: exp_1"
+                    "`variant_name` arg not provided in reddit_decider.expose() call for experiment: exp_1"
                     in x.getMessage()
                     for x in captured.records
                 )

--- a/tests/decider_tests.py
+++ b/tests/decider_tests.py
@@ -749,6 +749,24 @@ class TestDeciderGetVariantAndExpose(unittest.TestCase):
                 experiment_name="exp_1", variant=variant, event_fields=event_fields
             )
 
+    def test_expose_without_variant_name(self):
+        with create_temp_config_file(self.exp_base_config) as f:
+            decider = self.setup_decider(f.name, self.dc)
+
+            self.assertEqual(self.event_logger.log.call_count, 0)
+            variant = "variant_4"
+            with self.assertLogs() as captured:
+                decider.expose("exp_1", None)
+
+                assert any(
+                    '`variant_name` not provided in expose() call for experiment: exp_1'
+                    in x.getMessage()
+                    for x in captured.records
+                )
+
+            # exposure assertions
+            self.assertEqual(self.event_logger.log.call_count, 0)
+
     def test_get_variant_for_identifier_without_expose_user_id(self):
         identifier = USER_ID
         bucket_val = "user_id"

--- a/tests/decider_tests.py
+++ b/tests/decider_tests.py
@@ -751,7 +751,7 @@ class TestDeciderGetVariantAndExpose(unittest.TestCase):
 
     def test_expose_without_variant_name(self):
         with create_temp_config_file(self.exp_base_config) as f:
-            decider = self.setup_decider(f.name, self.dc)
+            decider = setup_decider(f.name, self.dc, self.mock_span, self.event_logger)
 
             self.assertEqual(self.event_logger.log.call_count, 0)
 

--- a/tests/experiment_tests.py
+++ b/tests/experiment_tests.py
@@ -287,14 +287,7 @@ class TestExperiments(unittest.TestCase):
 
         self.assertEqual(self.event_logger.log.call_count, 0)
 
-        with self.assertLogs() as captured:
-            experiments.expose("test", variant_name=None, user=self.user, app_name="r2")
-
-            assert any(
-                "`variant_name` arg not provided in reddit_experiments.expose() call for experiment: test"
-                in x.getMessage()
-                for x in captured.records
-            )
+        experiments.expose("test", variant_name=None, user=self.user, app_name="r2")
 
         self.assertEqual(self.event_logger.log.call_count, 0)
 


### PR DESCRIPTION
Drop exposure events that don't specify a `variant_name`.