### PR TITLE
Use `RustDecider#choose_all()` in `get_all_variants_without_expose()` & `get_all_variants_for_identifier_without_expose()` 

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -68,7 +68,7 @@ Upgrade or integrate reddit-experiments package:
 .. code-block:: python
 
     # import latest reddit-experiments package in service requirements.txt
-    reddit-experiments>=1.3.9
+    reddit-experiments>=1.3.11
 
 Initialize :code:`decider` instance on Baseplate context
 --------------------------------------------------------
@@ -126,7 +126,7 @@ Make sure :code:`EdgeContext` is accessible on :code:`request` object like so:
     #   - locale
     #   - origin_service
     #   - is_employee
-    #   - loid_created_ms (>=1.3.9)
+    #   - loid_created_ms (>=1.3.11)
 
     # Customized fields can be defined below to be extracted from a baseplate request
     # and will override above edge_context fields.

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,7 +4,7 @@ docutils==0.16
 Jinja2==2.11.2
 MarkupSafe==1.1.1
 pydocstyle==5.1.1
-reddit-decider==1.2.15
+reddit-decider==1.2.29
 reddit-edgecontext==1.0.0a3
 Sphinx==3.4.0
 sphinx-autodoc-typehints==1.11.1

--- a/reddit_decider/__init__.py
+++ b/reddit_decider/__init__.py
@@ -631,12 +631,13 @@ class Decider:
 
         for decision_dict in all_decisions:
             if decision_dict:
-                parsed_choices.append(self._transform_decision(decision_dict))
+                variant = decision_dict.get("variant")
+                if variant:
+                    parsed_choices.append(self._transform_decision(decision_dict))
 
-            # expose Holdout if the experiment is part of one
-            for event in decision_dict.get("events", []):
-                print(decision_dict)
-                self._send_expose_if_holdout(event=event, exposure_fields=event_context_fields)
+                # expose Holdout if the experiment is part of one
+                for event in decision_dict.get("events", []):
+                    self._send_expose_if_holdout(event=event, exposure_fields=event_context_fields)
 
         return parsed_choices
 

--- a/reddit_decider/__init__.py
+++ b/reddit_decider/__init__.py
@@ -626,7 +626,7 @@ class Decider:
 
         event_context_fields = self._decider_context.to_event_dict()
 
-        for decision in all_decisions:
+        for decision in all_decisions.values():
             if decision.variant:
                 parsed_choices.append(self._transform_decision(decision))
 
@@ -702,7 +702,7 @@ class Decider:
 
         event_context_fields = self._decider_context.to_event_dict()
 
-        for decision in all_decisions:
+        for decision in all_decisions.values():
             if decision.variant:
                 parsed_choices.append(self._transform_decision(decision))
 

--- a/reddit_decider/__init__.py
+++ b/reddit_decider/__init__.py
@@ -637,7 +637,6 @@ class Decider:
 
         return parsed_choices
 
-
     def _transform_decision(self, decision: Decision) -> Dict[str, Any]:
         return {
             "name": decision.variant,
@@ -694,7 +693,9 @@ class Decider:
         ctx[identifier_type] = identifier
 
         try:
-            all_decisions = self._internal.choose_all(context=ctx, bucketing_field_filter=identifier_type)
+            all_decisions = self._internal.choose_all(
+                context=ctx, bucketing_field_filter=identifier_type
+            )
         except DeciderException as exc:
             logger.info(exc)
             return []

--- a/reddit_decider/__init__.py
+++ b/reddit_decider/__init__.py
@@ -12,6 +12,9 @@ from typing import List
 from typing import Optional
 from typing import Union
 
+import rust_decider  # type: ignore
+from rust_decider import Decider as RustDecider
+
 from baseplate import RequestContext
 from baseplate import Span
 from baseplate.clients import ContextFactory

--- a/reddit_decider/__init__.py
+++ b/reddit_decider/__init__.py
@@ -12,9 +12,6 @@ from typing import List
 from typing import Optional
 from typing import Union
 
-import rust_decider  # type: ignore
-from rust_decider import Decider as RustDecider
-
 from baseplate import RequestContext
 from baseplate import Span
 from baseplate.clients import ContextFactory
@@ -621,7 +618,7 @@ class Decider:
 
         try:
             all_decisions = self._rs_decider.choose_all(ctx)
-        except ValueError as exc:
+        except DeciderException as exc:
             logger.info(exc)
             return []
 
@@ -629,25 +626,23 @@ class Decider:
 
         event_context_fields = self._decider_context.to_event_dict()
 
-        for decision_dict in all_decisions:
-            if decision_dict:
-                variant = decision_dict.get("variant")
-                if variant:
-                    parsed_choices.append(self._transform_decision(decision_dict))
+        for decision in all_decisions:
+            if decision.variant:
+                parsed_choices.append(self._transform_decision(decision))
 
-                # expose Holdout if the experiment is part of one
-                for event in decision_dict.get("events", []):
-                    self._send_expose_if_holdout(event=event, exposure_fields=event_context_fields)
+            # expose Holdout if the experiment is part of one
+            for event in decision.events:
+                self._send_expose_if_holdout(event=event, exposure_fields=event_context_fields)
 
         return parsed_choices
 
 
-    def _transform_decision(self, decision_dict: Dict[str, str]) -> Dict[str, Any]:
+    def _transform_decision(self, decision: Decision) -> Dict[str, Any]:
         return {
-            "name": decision_dict.get("variant"),
-            "id": decision_dict.get("experiment_id"),
-            "version": str(decision_dict.get("experiment_version")),
-            "experimentName": decision_dict.get("experiment_name"),
+            "name": decision.variant,
+            "id": decision.feature_id,
+            "version": str(decision.feature_version),
+            "experimentName": decision.feature_name,
         }
 
     def get_all_variants_for_identifier_without_expose(
@@ -690,48 +685,30 @@ class Decider:
             )
             return []
 
-        decider = self._get_decider()
-        if decider is None:
+        if self._rs_decider is None:
+            logger.error("rs_decider is None--did not initialize.")
             return []
 
-        ctx = self._get_ctx_with_set_identifier(
-            identifier=identifier, identifier_type=identifier_type
-        )
-        ctx_err = ctx.err()
-        if ctx_err is not None:
-            logger.info(f"Encountered error in rust_decider.make_ctx(): {ctx_err}")
+        ctx = self._decider_context.to_dict()
+        ctx[identifier_type] = identifier
+
+        try:
+            all_decisions = self._rs_decider.choose_all(context=ctx, bucketing_field_filter=identifier_type)
+        except DeciderException as exc:
+            logger.info(exc)
             return []
 
-        all_decisions_result = decider.choose_all(ctx=ctx, identifier_type=identifier_type)
-
-        error = all_decisions_result.err()
-        if error:
-            logger.info(f"Encountered error in decider.choose_all(): {error}")
-            return []
-
-        all_decisions = all_decisions_result.decisions()
         parsed_choices = []
 
         event_context_fields = self._decider_context.to_event_dict()
 
-        for exp_name, decision in all_decisions.items():
-            decision_error = decision.err()
-            if decision_error:
-                logger.info(
-                    f"Encountered error for experiment: {exp_name} in decider.choose_all(): {decision_error}"
-                )
-                continue
-
-            decision_dict = decision.decision_dict()
-
-            if decision_dict:
-                parsed_choices.append(self._format_decision(decision_dict))
+        for decision in all_decisions:
+            if decision.variant:
+                parsed_choices.append(self._transform_decision(decision))
 
             # expose Holdout if the experiment is part of one
-            for event in decision.events():
-                self._send_expose_if_holdout(
-                    event=event, exposure_fields=event_context_fields, overwrite_identifier=True
-                )
+            for event in decision.events:
+                self._send_expose_if_holdout(event=event, exposure_fields=event_context_fields)
 
         return parsed_choices
 

--- a/reddit_decider/__init__.py
+++ b/reddit_decider/__init__.py
@@ -24,6 +24,7 @@ from baseplate.lib.file_watcher import WatchedFileNotAvailableError
 from reddit_edgecontext import ValidatedAuthenticationToken
 from rust_decider import Decider as RustDecider
 from rust_decider import DeciderException
+from rust_decider import Decision
 from rust_decider import FeatureNotFoundException
 from rust_decider import make_ctx
 from typing_extensions import Literal
@@ -610,16 +611,16 @@ class Decider:
 
         :return: list of experiment dicts with non-:code:`None` variants.
         """
-        if self._rs_decider is None:
+        if self._internal is None:
             logger.error("rs_decider is None--did not initialize.")
             return []
 
         ctx = self._decider_context.to_dict()
 
         try:
-            all_decisions = self._rs_decider.choose_all(ctx)
+            all_decisions = self._internal.choose_all(ctx)
         except DeciderException as exc:
-            logger.info(exc)
+            logger.info(str(exc))
             return []
 
         parsed_choices = []
@@ -685,7 +686,7 @@ class Decider:
             )
             return []
 
-        if self._rs_decider is None:
+        if self._internal is None:
             logger.error("rs_decider is None--did not initialize.")
             return []
 
@@ -693,7 +694,7 @@ class Decider:
         ctx[identifier_type] = identifier
 
         try:
-            all_decisions = self._rs_decider.choose_all(context=ctx, bucketing_field_filter=identifier_type)
+            all_decisions = self._internal.choose_all(context=ctx, bucketing_field_filter=identifier_type)
         except DeciderException as exc:
             logger.info(exc)
             return []

--- a/reddit_decider/__init__.py
+++ b/reddit_decider/__init__.py
@@ -629,7 +629,7 @@ class Decider:
 
         for decision in all_decisions.values():
             if decision.variant:
-                parsed_choices.append(self._transform_decision(decision))
+                parsed_choices.append(self._decision_to_dict(decision))
 
             # expose Holdout if the experiment is part of one
             for event in decision.events:
@@ -637,7 +637,7 @@ class Decider:
 
         return parsed_choices
 
-    def _transform_decision(self, decision: Decision) -> Dict[str, Any]:
+    def _decision_to_dict(self, decision: Decision) -> Dict[str, Any]:
         return {
             "name": decision.variant,
             "id": decision.feature_id,
@@ -706,7 +706,7 @@ class Decider:
 
         for decision in all_decisions.values():
             if decision.variant:
-                parsed_choices.append(self._transform_decision(decision))
+                parsed_choices.append(self._decision_to_dict(decision))
 
             # expose Holdout if the experiment is part of one
             for event in decision.events:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 -r requirements-transitive.txt
 baseplate==2.0.0a1
 black==21.4b2
-reddit-decider==1.2.28
+reddit-decider==1.2.29
 flake8==3.9.1
 mypy==0.790
 pyramid==2.0   # required for `from baseplate.frameworks.pyramid import BaseplateRequest` which calls `import pyramid.events`

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     install_requires=[
         "baseplate>=2.0.0a1,<3.0",
         "reddit-edgecontext>=1.0.0a3,<2.0",
-        "reddit-decider~=1.2.28",
+        "reddit-decider~=1.2.29",
         "typing_extensions>=3.10.0.0,<5.0",
     ],
     package_data={"reddit_experiments": ["py.typed"]},

--- a/tests/decider_tests.py
+++ b/tests/decider_tests.py
@@ -980,9 +980,7 @@ class TestDeciderGetVariantAndExpose(unittest.TestCase):
         self.exp_base_config.update(self.additional_two_exp)
 
         with create_temp_config_file(self.exp_base_config) as f:
-            decider = setup_decider(
-                f, dc, self.mock_span, self.event_logger
-            )
+            decider = setup_decider(f, dc, self.mock_span, self.event_logger)
 
             self.assertEqual(self.event_logger.log.call_count, 0)
 
@@ -1003,7 +1001,6 @@ class TestDeciderGetVariantAndExpose(unittest.TestCase):
 
             # no exposures should be triggered
             self.assertEqual(self.event_logger.log.call_count, 0)
-
 
     def test_get_all_variants_for_identifier_without_expose_user_id(self):
         identifier = USER_ID

--- a/tests/decider_tests.py
+++ b/tests/decider_tests.py
@@ -1182,7 +1182,9 @@ class TestDeciderGetVariantAndExpose(unittest.TestCase):
         # add 2 more experiments
         self.exp_base_config.update(self.additional_two_exp)
 
-        for exp_name in self.exp_base_config.keys():
+        # update 2 of 3 experiments to have bucket_val: 'canonical_url'
+        # so that the 3rd one is filtered out
+        for exp_name in list(self.exp_base_config.keys())[0:2]:
             self.exp_base_config[exp_name]["experiment"].update({"bucket_val": bucket_val})
 
         with create_temp_config_file(self.exp_base_config) as f:
@@ -1193,7 +1195,7 @@ class TestDeciderGetVariantAndExpose(unittest.TestCase):
                 identifier=identifier, identifier_type=bucket_val
             )
 
-            self.assertEqual(len(variant_arr), len(self.exp_base_config))
+            self.assertEqual(len(variant_arr), 2)
             self.assertEqual(
                 first_occurrence_of_key_in(variant_arr, "experimentName", "exp_1"),
                 {"id": 1, "name": "variant_3", "version": "2", "experimentName": "exp_1"},
@@ -1201,10 +1203,6 @@ class TestDeciderGetVariantAndExpose(unittest.TestCase):
             self.assertEqual(
                 first_occurrence_of_key_in(variant_arr, "experimentName", "e1"),
                 {"id": 6, "name": "e1treat", "version": "4", "experimentName": "e1"},
-            )
-            self.assertEqual(
-                first_occurrence_of_key_in(variant_arr, "experimentName", "e2"),
-                {"id": 7, "name": "e2treat", "version": "5", "experimentName": "e2"},
             )
 
             # no exposures should be triggered

--- a/tests/decider_tests.py
+++ b/tests/decider_tests.py
@@ -972,7 +972,7 @@ class TestDeciderGetVariantAndExpose(unittest.TestCase):
                 experiment_name="hg", variant="holdout", event_fields=event_fields
             )
 
-    def test_get_all_variants_without_expose_ctx_missing_bucketing_key_exception(self):
+    def test_get_all_variants_without_expose_ctx_missing_device_id(self):
         # no device_id in ctx
         dc = DeciderContext(user_id=USER_ID)
 
@@ -988,6 +988,8 @@ class TestDeciderGetVariantAndExpose(unittest.TestCase):
 
             decision_arr = decider.get_all_variants_without_expose()
 
+            # device_id experiment not bucketed since
+            # device_id is missing in ctx
             self.assertEqual(len(decision_arr), 2)
 
             self.assertEqual(
@@ -1226,6 +1228,7 @@ class TestDeciderGetVariantAndExpose(unittest.TestCase):
                 identifier=identifier, identifier_type=bucket_val
             )
 
+            # non-canonical_url experiment is not included in result
             self.assertEqual(len(variant_arr), 2)
             self.assertEqual(
                 first_occurrence_of_key_in(variant_arr, "experimentName", "exp_1"),

--- a/tests/decider_tests.py
+++ b/tests/decider_tests.py
@@ -972,6 +972,37 @@ class TestDeciderGetVariantAndExpose(unittest.TestCase):
                 experiment_name="hg", variant="holdout", event_fields=event_fields
             )
 
+    def test_get_all_variants_without_expose_ctx_missing_bucketing_key_exception(self):
+        # no device_id in ctx
+        dc = DeciderContext(user_id=USER_ID)
+
+        self.exp_base_config["exp_1"]["experiment"].update({"bucket_val": "device_id"})
+        self.exp_base_config.update(self.additional_two_exp)
+
+        with create_temp_config_file(self.exp_base_config) as f:
+            decider = setup_decider(
+                f, dc, self.mock_span, self.event_logger
+            )
+
+            self.assertEqual(self.event_logger.log.call_count, 0)
+
+            decision_arr = decider.get_all_variants_without_expose()
+
+            self.assertEqual(len(decision_arr), 2)
+
+            self.assertEqual(
+                first_occurrence_of_key_in(decision_arr, "experimentName", "e1"),
+                {"id": 6, "name": "e1treat", "version": "4", "experimentName": "e1"},
+            )
+            self.assertEqual(
+                first_occurrence_of_key_in(decision_arr, "experimentName", "e2"),
+                {"id": 7, "name": "e2treat", "version": "5", "experimentName": "e2"},
+            )
+
+            # no exposures should be triggered
+            self.assertEqual(self.event_logger.log.call_count, 0)
+
+
     def test_get_all_variants_for_identifier_without_expose_user_id(self):
         identifier = USER_ID
         bucket_val = "user_id"


### PR DESCRIPTION
# Summary 
Utilize `rust_decider.RustDecider#choose_all()` in`get_all_variants_without_expose()` & `get_all_variants_for_identifier_without_expose()` 
(instead of `rust_decider.make_ctx()`/`rust_decider.choose_all()` functions)
to emit prometheus metrics.

*pending new release of decider package, tested locally with local build