### PR TITLE
Use `RustDecider#choose()` in `for_identifier*()` api

### DIFF
--- a/reddit_decider/__init__.py
+++ b/reddit_decider/__init__.py
@@ -453,6 +453,14 @@ class Decider:
     ) -> Optional[str]:
         """Return a bucketing variant, if any, with auto-exposure for a given :code:`identifier`.
 
+        Note: If the experiment's :code:`bucket_val` (e.g. "user_id", "device_id", "canonical_url")
+            does not match the :code:`identifier_type` param,
+            the :code:`identifier` will be ignored and not used to bucket (:code:`{identifier_type: identifier}` is
+            added to internal :code:`DeciderContext` instance, but doesn't act like a bucketing override).
+
+            If the :code:`bucket_val` field exists on the :code:`DeciderContext` instance,
+            that field will be used to bucket, since it corresponds to the experiment's config.
+
         Since calling :code:`get_variant_for_identifier()` will fire an exposure event, it
         is best to call it when you are sure the user will be exposed to the experiment.
 
@@ -461,8 +469,11 @@ class Decider:
         :param identifier: an arbitary string used to bucket the experiment by
             being set on :code:`DeciderContext`'s :code:`identifier_type` field.
 
-        :param identifier_type: Sets :code:`{identifier_type: identifier}` on DeciderContext and
-            should match an experiment's :code:`bucket_val` to get a variant.
+        :param identifier_type: Sets :code:`{identifier_type: identifier}` on :code:`DeciderContext`.
+            The experiment's :code:`bucket_val` will be looked up in :code:`DeciderContext` and be used to bucket.
+            If the experiment's :code:`bucket_val` field does not match :code:`identifier_type` param,
+            :code:`identifier` will be ignored, and the field corresponding :code:`bucket_val` will be looked up
+            from :code:`DeciderContext` for bucketing.
 
         :param exposure_kwargs: Additional arguments that will be passed
             to :code:`events_logger` (keys must be part of v2 event schema,
@@ -509,6 +520,14 @@ class Decider:
     ) -> Optional[str]:
         """Return a bucketing variant, if any, without emitting exposure event for a given :code:`identifier`.
 
+        Note: If the experiment's :code:`bucket_val` (e.g. "user_id", "device_id", "canonical_url")
+            does not match the :code:`identifier_type` param,
+            the :code:`identifier` will be ignored and not used to bucket (:code:`{identifier_type: identifier}` is
+            added to internal :code:`DeciderContext` instance, but doesn't act like a bucketing override).
+
+            If the :code:`bucket_val` field exists on the :code:`DeciderContext` instance,
+            that field will be used to bucket, since it corresponds to the experiment's config.
+
         The :code:`expose()` function is available to be manually called afterward to emit
         exposure event.
 
@@ -523,8 +542,11 @@ class Decider:
         :param identifier: an arbitary string used to bucket the experiment by
             being set on :code:`DeciderContext`'s :code:`identifier_type` field.
 
-        :param identifier_type: Sets :code:`{identifier_type: identifier}` on DeciderContext and
-            should match an experiment's :code:`bucket_val` to get a variant.
+        :param identifier_type: Sets :code:`{identifier_type: identifier}` on :code:`DeciderContext`.
+            The experiment's :code:`bucket_val` will be looked up in :code:`DeciderContext` and be used to bucket.
+            If the experiment's :code:`bucket_val` field does not match :code:`identifier_type` param,
+            :code:`identifier` will be ignored and the field corresponding :code:`bucket_val` will be looked up
+            from :code:`DeciderContext` for bucketing.
 
         :return: Variant name if a variant is assigned, None otherwise.
         """
@@ -625,7 +647,8 @@ class Decider:
     def get_all_variants_for_identifier_without_expose(
         self, identifier: str, identifier_type: Literal["user_id", "device_id", "canonical_url"]
     ) -> List[Dict[str, Union[str, int]]]:
-        """Return a list of experiment dicts for a given :code:`identifier` in this format:
+        """Return a list of experiment dicts for experiments having :code:`bucket_val` match
+        :code:`identifier_type`, for a given :code:`identifier`, in this format:
 
                 .. code-block:: json
 
@@ -652,7 +675,7 @@ class Decider:
             being set on :code:`DeciderContext`'s :code:`identifier_type` field.
 
         :param identifier_type: Sets :code:`{identifier_type: identifier}` on DeciderContext and
-            should match an experiment's :code:`bucket_val` to get a variant.
+            buckets all experiment with matching :code:`bucket_val`.
 
         :return: list of experiment dicts with non-:code:`None` variants.
         """

--- a/reddit_decider/__init__.py
+++ b/reddit_decider/__init__.py
@@ -212,9 +212,7 @@ class Decider:
 
         return out
 
-    def _send_expose(
-        self, event: str, exposure_fields: dict, overwrite_identifier: bool = False
-    ) -> None:
+    def _send_expose(self, event: str, exposure_fields: dict) -> None:
         event_fields = deepcopy(exposure_fields)
         try:
             (
@@ -245,8 +243,7 @@ class Decider:
             owner=owner,
         )
 
-        if overwrite_identifier:
-            event_fields = {**event_fields, **{bucket_val: bucketing_value}}
+        event_fields = {**event_fields, **{bucket_val: bucketing_value}}
 
         self._event_logger.log(
             experiment=experiment,
@@ -258,9 +255,7 @@ class Decider:
         )
         return
 
-    def _send_expose_if_holdout(
-        self, event: str, exposure_fields: dict, overwrite_identifier: bool = False
-    ) -> None:
+    def _send_expose_if_holdout(self, event: str, exposure_fields: dict) -> None:
         event_fields = deepcopy(exposure_fields)
         try:
             (
@@ -296,8 +291,7 @@ class Decider:
                 owner=owner,
             )
 
-            if overwrite_identifier:
-                event_fields = {**event_fields, **{bucket_val: bucketing_value}}
+            event_fields = {**event_fields, **{bucket_val: bucketing_value}}
 
             self._event_logger.log(
                 experiment=experiment,
@@ -503,9 +497,7 @@ class Decider:
         event_context_fields.update(exposure_kwargs or {})
 
         for event in decision.events:
-            self._send_expose(
-                event=event, exposure_fields=event_context_fields, overwrite_identifier=True
-            )
+            self._send_expose(event=event, exposure_fields=event_context_fields)
 
         return decision.variant
 
@@ -562,9 +554,7 @@ class Decider:
 
         # expose Holdout if the experiment is part of one
         for event in decision.events:
-            self._send_expose_if_holdout(
-                event=event, exposure_fields=event_context_fields, overwrite_identifier=True
-            )
+            self._send_expose_if_holdout(event=event, exposure_fields=event_context_fields)
 
         return decision.variant
 


### PR DESCRIPTION
# Summary 
Utilize `rust_decider.RustDecider#choose()` in `get_variant_for_identifier()` & `get_variant_for_identifier_without_expose()` 
(instead of `rust_decider.make_ctx()`/`rust_decider.choose()` functions)
to emit prometheus metrics.

# Notes
<b>1)</b> 
If a ctx contains the field that a Feature config, called through `get_variant_for_identifier()`, needs for bucketing, it will get utilized, since there's no concept of `identifier_type` in `RustDecider#choose()`  forcing the bucketing to override (we just set `ctx[identifier_type] = identifier`).  

e.g. if a Feature "exp_1" with `bucket_val: device_id` gets called via:
`get_variant_for_identifier("exp_1", identifier="identifier.com", identifier_type="canonical_url")`
BUT has the `device_id` field set on ctx, it will use `device_id` for bucketing, not 
`"identifier.com", identifier_type="canonical_url"` params.

  The only way to establish similar behavior as before would be to clear the other two identifiers in ctx that aren't of the `identifier_type` param, e.g. clear `device_id`/`user_id` from ctx and set `canonical_url: "identifier.com"` on it.

  This is why I deleted 2 test cases..but maybe it is worth clearing the other bucketing fields in ctx?

<b>2)</b>
Removed the `overwrite_identifier: bool` param/logic in `_send_expose()`/`_send_expose_if_holdout`, since we should always use/set the `bucket_val: bucketing_value` in the v2 exposure event based on the decider event string, not just in some cases, when we had a `for_identifier*()` "override" .