### PR TITLE
Add `emit_event` field to `get_experiment()` return `ExperimentConfig`

### DIFF
--- a/reddit_decider/__init__.py
+++ b/reddit_decider/__init__.py
@@ -49,6 +49,7 @@ class ExperimentConfig:
     start_ts: int
     stop_ts: int
     owner: str
+    emit_event: Optional[bool] = None
 
 
 class DeciderContext:
@@ -890,6 +891,7 @@ class Decider:
             start_ts=exp_dict.get("variant_set", {}).get("start_ts"),
             stop_ts=exp_dict.get("variant_set", {}).get("stop_ts"),
             owner=exp_dict.get("owner"),
+            emit_event=bool(exp_dict.get("emit_event")),
         )
 
 

--- a/tests/decider_tests.py
+++ b/tests/decider_tests.py
@@ -1313,6 +1313,7 @@ class TestDeciderGetVariantAndExpose(unittest.TestCase):
             self.assertEqual(experiment.start_ts, cfg["start_ts"])
             self.assertEqual(experiment.stop_ts, cfg["stop_ts"])
             self.assertEqual(experiment.owner, cfg["owner"])
+            self.assertEqual(experiment.emit_event, True)
 
     def test_get_variant_without_expose_with_HG_as_control_1_and_child_returns_none_does_expose(
         self,


### PR DESCRIPTION
Request to also return "emit_event" field via `get_experiment()` api as part of `ExperimentConfig` dataclass return value.
Goal is to be able to differentiate Feature Rollouts from regular experiments.