### PR TITLE
Add DCs from decider-py shim (metrics)

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,7 +4,7 @@ docutils==0.16
 Jinja2==2.11.2
 MarkupSafe==1.1.1
 pydocstyle==5.1.1
-reddit-decider==1.2.29
+reddit-decider==1.2.30
 reddit-edgecontext==1.0.0a3
 Sphinx==3.4.0
 sphinx-autodoc-typehints==1.11.1

--- a/reddit_decider/__init__.py
+++ b/reddit_decider/__init__.py
@@ -696,32 +696,6 @@ class Decider:
 
         return parsed_choices
 
-    def _get_dynamic_config_value(
-        self,
-        feature_name: str,
-        default: Any,
-        dc_types: List[str],
-    ) -> Any:
-        if self._internal is None:
-            logger.error("rs_decider is None--did not initialize.")
-            return default
-
-        ctx = self._decider_context.to_dict()
-
-        try:
-            decision = self._internal.choose(feature_name=feature_name, context=ctx)
-        except FeatureNotFoundException as exc:
-            warnings.warn(str(exc))
-            return default
-        except DeciderException as exc:
-            logger.info(str(exc))
-            return default
-
-        if decision.value_type not in dc_types:
-            return default
-
-        return decision.value
-
     def get_bool(self, feature_name: str, default: bool = False) -> bool:
         """Fetch a Dynamic Configuration of boolean type.
 
@@ -833,6 +807,32 @@ class Decider:
             parsed_configs.append(self._decision_to_dc_dict(decision))
 
         return parsed_configs
+
+    def _get_dynamic_config_value(
+        self,
+        feature_name: str,
+        default: Any,
+        dc_types: List[str],
+    ) -> Any:
+        if self._internal is None:
+            logger.error("rs_decider is None--did not initialize.")
+            return default
+
+        ctx = self._decider_context.to_dict()
+
+        try:
+            decision = self._internal.choose(feature_name=feature_name, context=ctx)
+        except FeatureNotFoundException as exc:
+            warnings.warn(str(exc))
+            return default
+        except DeciderException as exc:
+            logger.info(str(exc))
+            return default
+
+        if decision.value_type not in dc_types:
+            return default
+
+        return decision.value
 
     def _decision_to_dc_dict(self, decision: Decision) -> Dict[str, Any]:
         return {

--- a/reddit_decider/__init__.py
+++ b/reddit_decider/__init__.py
@@ -700,7 +700,7 @@ class Decider:
         self,
         feature_name: str,
         default: Any,
-    ) -> Optional[Any]:
+    ) -> Decision:
         if self._internal is None:
             logger.error("rs_decider is None--did not initialize.")
             return default

--- a/reddit_decider/__init__.py
+++ b/reddit_decider/__init__.py
@@ -10,6 +10,8 @@ from typing import Dict
 from typing import IO
 from typing import List
 from typing import Optional
+from typing import Type
+from typing import TypeVar
 from typing import Union
 
 from baseplate import RequestContext
@@ -64,6 +66,7 @@ class DeciderContext:
     bucketing, targeting, and overrides.
     :code:`DeciderContext()` is populated in :code:`make_object_for_context()`.
     """
+    T = TypeVar("T")
 
     def __init__(
         self,
@@ -819,8 +822,8 @@ class Decider:
         self,
         feature_name: str,
         default: Any,
-        dc_type: Any,
-    ) -> Any:
+        dc_type: Type[T],
+    ) -> T:
         if self._internal is None:
             logger.error("rs_decider is None--did not initialize.")
             return default
@@ -840,7 +843,7 @@ class Decider:
             return default
 
         try:
-            return dc_type(value)
+            return dc_type(value)  # type: ignore [call-arg]
         except TypeError:
             return default
 

--- a/reddit_decider/__init__.py
+++ b/reddit_decider/__init__.py
@@ -39,6 +39,7 @@ EMPLOYEE_ROLES = ["employee", "contractor"]
 IDENTIFIERS = ["user_id", "device_id", "canonical_url"]
 TYPE_STR_LOOKUP = {bool: "boolean", int: "integer", float: "float", str: "string", dict: "map"}
 
+
 class EventType(Enum):
     EXPOSE = "expose"
 

--- a/reddit_decider/__init__.py
+++ b/reddit_decider/__init__.py
@@ -179,7 +179,7 @@ class Decider:
         event_logger: Optional[EventLogger] = None,
     ):
         self._decider_context = decider_context
-        self._internal = internal
+        self._internal: RustDecider = internal
         self._span = server_span
         self._context_name = context_name
         if event_logger:
@@ -821,7 +821,7 @@ class Decider:
         feature_name: str,
         default: Any,
         dc_type: Type[T],
-        get_fn: Callable,
+        get_fn: Callable[..., Type[T]],
     ) -> T:
         if self._internal is None:
             logger.error("rs_decider is None--did not initialize.")

--- a/reddit_decider/__init__.py
+++ b/reddit_decider/__init__.py
@@ -37,13 +37,7 @@ logger = logging.getLogger(__name__)
 
 EMPLOYEE_ROLES = ["employee", "contractor"]
 IDENTIFIERS = ["user_id", "device_id", "canonical_url"]
-TYPE_STR_LOOKUP = {
-    bool: "boolean",
-    int: "integer",
-    float: "float",
-    str: "string",
-    dict: "map"
-}
+TYPE_STR_LOOKUP = {bool: "boolean", int: "integer", float: "float", str: "string", dict: "map"}
 
 class EventType(Enum):
     EXPOSE = "expose"
@@ -66,6 +60,7 @@ class DeciderContext:
     bucketing, targeting, and overrides.
     :code:`DeciderContext()` is populated in :code:`make_object_for_context()`.
     """
+
     T = TypeVar("T")
 
     def __init__(
@@ -831,7 +826,9 @@ class Decider:
         ctx = self._decider_context.to_dict()
 
         try:
-            value = eval(f"self._internal.get_{dc_type.__name__}")(feature_name=feature_name, context=ctx)
+            value = eval(f"self._internal.get_{dc_type.__name__}")(
+                feature_name=feature_name, context=ctx
+            )
         except FeatureNotFoundException as exc:
             warnings.warn(str(exc))
             return default

--- a/reddit_decider/__init__.py
+++ b/reddit_decider/__init__.py
@@ -712,7 +712,7 @@ class Decider:
 
         :return: the boolean value of the dyanimc config if it is active/exists, :code:`default` parameter otherwise.
         """
-        return self._get_dynamic_config_value(feature_name, default, bool)
+        return self._get_dynamic_config_value(feature_name, default, bool, self._internal.get_bool)
 
     def get_int(self, feature_name: str, default: int = 0) -> int:
         """Fetch a Dynamic Configuration of int type.
@@ -724,7 +724,7 @@ class Decider:
 
         :return: the int value of the dyanimc config if it is active/exists, :code:`default` parameter otherwise.
         """
-        return self._get_dynamic_config_value(feature_name, default, int)
+        return self._get_dynamic_config_value(feature_name, default, int, self._internal.get_int)
 
     def get_float(self, feature_name: str, default: float = 0.0) -> float:
         """Fetch a Dynamic Configuration of float type.
@@ -736,7 +736,7 @@ class Decider:
 
         :return: the float value of the dyanimc config if it is active/exists, :code:`default` parameter otherwise.
         """
-        return self._get_dynamic_config_value(feature_name, default, float)
+        return self._get_dynamic_config_value(feature_name, default, float, self._internal.get_float)
 
     def get_string(self, feature_name: str, default: str = "") -> str:
         """Fetch a Dynamic Configuration of string type.
@@ -748,7 +748,7 @@ class Decider:
 
         :return: the string value of the dyanimc config if it is active/exists, :code:`default` parameter otherwise.
         """
-        return self._get_dynamic_config_value(feature_name, default, str)
+        return self._get_dynamic_config_value(feature_name, default, str, self._internal.get_string)
 
     def get_map(self, feature_name: str, default: Optional[dict] = None) -> Optional[dict]:
         """Fetch a Dynamic Configuration of map type.
@@ -760,7 +760,7 @@ class Decider:
 
         :return: the map value of the dyanimc config if it is active/exists, :code:`default` parameter otherwise.
         """
-        return self._get_dynamic_config_value(feature_name, default, dict)
+        return self._get_dynamic_config_value(feature_name, default, dict, self._internal.get_map)
 
     def get_all_dynamic_configs(self) -> List[Dict[str, Any]]:
         """Return a list of dynamic configuration dicts in this format:
@@ -819,6 +819,7 @@ class Decider:
         feature_name: str,
         default: Any,
         dc_type: Type[T],
+        get_fn: Callable,
     ) -> T:
         if self._internal is None:
             logger.error("rs_decider is None--did not initialize.")
@@ -827,9 +828,7 @@ class Decider:
         ctx = self._decider_context.to_dict()
 
         try:
-            value = eval(f"self._internal.get_{dc_type.__name__}")(
-                feature_name=feature_name, context=ctx
-            )
+            value = get_fn(feature_name=feature_name, context=ctx)
         except FeatureNotFoundException as exc:
             warnings.warn(str(exc))
             return default

--- a/reddit_decider/__init__.py
+++ b/reddit_decider/__init__.py
@@ -700,7 +700,8 @@ class Decider:
         self,
         feature_name: str,
         default: Any,
-    ) -> Decision:
+        dc_types: List[str],
+    ) -> Any:
         if self._internal is None:
             logger.error("rs_decider is None--did not initialize.")
             return default
@@ -711,12 +712,15 @@ class Decider:
             decision = self._internal.choose(feature_name=feature_name, context=ctx)
         except FeatureNotFoundException as exc:
             warnings.warn(str(exc))
-            return None
+            return default
         except DeciderException as exc:
             logger.info(str(exc))
             return default
 
-        return decision
+        if decision.value_type not in dc_types:
+            return default
+
+        return decision.value
 
     def get_bool(self, feature_name: str, default: bool = False) -> bool:
         """Fetch a Dynamic Configuration of boolean type.
@@ -728,10 +732,7 @@ class Decider:
 
         :return: the boolean value of the dyanimc config if it is active/exists, :code:`default` parameter otherwise.
         """
-        decision = self._get_dynamic_config_value(feature_name, default)
-        if decision.value_type != "boolean":
-            return default
-        return decision.value
+        return self._get_dynamic_config_value(feature_name, default, ["boolean"])
 
     def get_int(self, feature_name: str, default: int = 0) -> int:
         """Fetch a Dynamic Configuration of int type.
@@ -743,12 +744,7 @@ class Decider:
 
         :return: the int value of the dyanimc config if it is active/exists, :code:`default` parameter otherwise.
         """
-        decision = self._get_dynamic_config_value(feature_name, default)
-
-        if decision.value_type != "integer":
-            return default
-
-        return decision.value
+        return self._get_dynamic_config_value(feature_name, default, ["integer"])
 
     def get_float(self, feature_name: str, default: float = 0.0) -> float:
         """Fetch a Dynamic Configuration of float type.
@@ -760,12 +756,7 @@ class Decider:
 
         :return: the float value of the dyanimc config if it is active/exists, :code:`default` parameter otherwise.
         """
-        decision = self._get_dynamic_config_value(feature_name, default)
-
-        if decision.value_type != "float" and decision.value_type != "integer":
-            return default
-
-        return decision.value
+        return self._get_dynamic_config_value(feature_name, default, ["float", "integer"])
 
     def get_string(self, feature_name: str, default: str = "") -> str:
         """Fetch a Dynamic Configuration of string type.
@@ -777,12 +768,7 @@ class Decider:
 
         :return: the string value of the dyanimc config if it is active/exists, :code:`default` parameter otherwise.
         """
-        decision = self._get_dynamic_config_value(feature_name, default)
-
-        if decision.value_type != "string" and decision.value_type != "Text":
-            return default
-
-        return decision.value
+        return self._get_dynamic_config_value(feature_name, default, ["string"])
 
     def get_map(self, feature_name: str, default: Optional[dict] = None) -> Optional[dict]:
         """Fetch a Dynamic Configuration of map type.
@@ -794,12 +780,7 @@ class Decider:
 
         :return: the map value of the dyanimc config if it is active/exists, :code:`default` parameter otherwise.
         """
-        decision = self._get_dynamic_config_value(feature_name, default)
-
-        if decision.value_type != "map":
-            return default
-
-        return decision.value
+        return self._get_dynamic_config_value(feature_name, default, ["map"])
 
     def get_all_dynamic_configs(self) -> List[Dict[str, Any]]:
         """Return a list of dynamic configuration dicts in this format:

--- a/reddit_decider/__init__.py
+++ b/reddit_decider/__init__.py
@@ -736,7 +736,9 @@ class Decider:
 
         :return: the float value of the dyanimc config if it is active/exists, :code:`default` parameter otherwise.
         """
-        return self._get_dynamic_config_value(feature_name, default, float, self._internal.get_float)
+        return self._get_dynamic_config_value(
+            feature_name, default, float, self._internal.get_float
+        )
 
     def get_string(self, feature_name: str, default: str = "") -> str:
         """Fetch a Dynamic Configuration of string type.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 -r requirements-transitive.txt
 baseplate==2.0.0a1
 black==21.4b2
-reddit-decider==1.2.30
+reddit-decider==1.2.29
 flake8==3.9.1
 mypy==0.790
 pyramid==2.0   # required for `from baseplate.frameworks.pyramid import BaseplateRequest` which calls `import pyramid.events`

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 -r requirements-transitive.txt
 baseplate==2.0.0a1
 black==21.4b2
-reddit-decider==1.2.29
+reddit-decider==1.2.30
 flake8==3.9.1
 mypy==0.790
 pyramid==2.0   # required for `from baseplate.frameworks.pyramid import BaseplateRequest` which calls `import pyramid.events`

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     install_requires=[
         "baseplate>=2.0.0a1,<3.0",
         "reddit-edgecontext>=1.0.0a3,<2.0",
-        "reddit-decider~=1.2.29",
+        "reddit-decider~=1.2.30",
         "typing_extensions>=3.10.0.0,<5.0",
     ],
     package_data={"reddit_experiments": ["py.typed"]},

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     install_requires=[
         "baseplate>=2.0.0a1,<3.0",
         "reddit-edgecontext>=1.0.0a3,<2.0",
-        "reddit-decider~=1.2.30",
+        "reddit-decider~=1.2.29",
         "typing_extensions>=3.10.0.0,<5.0",
     ],
     package_data={"reddit_experiments": ["py.typed"]},

--- a/tests/decider_tests.py
+++ b/tests/decider_tests.py
@@ -1696,11 +1696,10 @@ class TestDeciderGetDynamicConfig(unittest.TestCase):
                 {"name": "dc_missing_map", "value": {}, "type": "map"},
             )
 
-            # set "type" to empty string if "value_type" is missing on cfg
             missing_map_val_res = first_occurrence_of_key_in(
                 configs, "name", "dc_missing_value_type"
             )
             self.assertEqual(
                 missing_map_val_res,
-                {"name": "dc_missing_value_type", "value": False, "type": ""},
+                {"name": "dc_missing_value_type", "value": False, "type": "boolean"},
             )


### PR DESCRIPTION
All DCs now go through the new `choose()` method from the decider-py shim.

Individual `get_{dc}()` calls are checked for matching `value_type` and return the `default` param if there's a mismatch to maintain backwards compatibility.