### PR TITLE
Update `get_experiment()` to use decider shim & remove last decider bindings usage

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,7 +4,7 @@ docutils==0.16
 Jinja2==2.11.2
 MarkupSafe==1.1.1
 pydocstyle==5.1.1
-reddit-decider==1.2.30
+reddit-decider==1.2.31
 reddit-edgecontext==1.0.0a3
 Sphinx==3.4.0
 sphinx-autodoc-typehints==1.11.1

--- a/reddit_decider/__init__.py
+++ b/reddit_decider/__init__.py
@@ -28,7 +28,6 @@ from rust_decider import Decider as RustDecider
 from rust_decider import DeciderException
 from rust_decider import Decision
 from rust_decider import FeatureNotFoundException
-from rust_decider import make_ctx
 from rust_decider import ValueTypeMismatchException
 from typing_extensions import Literal
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 -r requirements-transitive.txt
 baseplate==2.0.0a1
 black==21.4b2
-reddit-decider==1.2.30
+reddit-decider==1.2.31
 flake8==3.9.1
 mypy==0.790
 pyramid==2.0   # required for `from baseplate.frameworks.pyramid import BaseplateRequest` which calls `import pyramid.events`

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     install_requires=[
         "baseplate>=2.0.0a1,<3.0",
         "reddit-edgecontext>=1.0.0a3,<2.0",
-        "reddit-decider~=1.2.30",
+        "reddit-decider~=1.2.31",
         "typing_extensions>=3.10.0.0,<5.0",
     ],
     package_data={"reddit_experiments": ["py.typed"]},


### PR DESCRIPTION
By updating `get_experiment()` to use the shim's `get_feature()`, we eliminate the last dependency on the previous py bindings (accessed via `get_decider()`), and also add metrics to the function.