### PR TITLE
Fix inaccurate timeout docstring

### DIFF
--- a/reddit_decider/__init__.py
+++ b/reddit_decider/__init__.py
@@ -1165,7 +1165,7 @@ def decider_client_from_config(
             experiment configuration fetcher daemon.
         ``timeout`` (optional)
             The time that we should wait for the file specified by ``path`` to
-            exist.  Defaults to `None` which is `infinite`.
+            exist.  Defaults to `None` which is not blocking.
         ``backoff`` (optional)
             The base amount of time for exponential backoff when trying to find the
             experiments config file. Defaults to no backoff between tries.


### PR DESCRIPTION
## 💸 TL;DR
Timeout docstring is misleading.

## 📜 Details
The docstring on the `timeout` config key implies that if no value for a timeout is provided, initilization will block forever. This disagrees with the `DeciderContextFactory` docstring (`"defaults to not blocking"`) and the underlying Baseplate `FileWatcher` ([source](https://github.com/reddit/baseplate.py/blob/f29bd1ce0f1ec4962f65ecd5a2b016b1cd4fd5ac/baseplate/lib/file_watcher.py#L82)).

We've also seen this not block in production. Logs can be provided if needed.

<!-- Add additional details required for the PR: breaking changes, screenshots, external dependency changes -->

## 🧪 Testing Steps / Validation
Just a docstring update. No tests needed.
## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] CI tests (if present) are passing
- [ ] Adheres to code style for repo
- [ ] Contributor License Agreement (CLA) completed if not a Reddit employee
