### PR TITLE
Log 'feature not found' to debug logger

### DIFF
--- a/reddit_decider/__init__.py
+++ b/reddit_decider/__init__.py
@@ -1,5 +1,4 @@
 import logging
-import warnings
 
 from copy import deepcopy
 from dataclasses import dataclass
@@ -375,7 +374,7 @@ class Decider:
         try:
             feature = self._internal.get_feature(experiment_name)
         except FeatureNotFoundException as exc:
-            warnings.warn(str(exc))
+            logger.debug(str(exc))
             return
         except DeciderException as exc:
             logger.info(str(exc))
@@ -772,7 +771,7 @@ class Decider:
         try:
             return self._internal.choose(experiment_name, ctx)
         except FeatureNotFoundException as exc:
-            warnings.warn(str(exc))
+            logger.debug(str(exc))
             return None
         except DeciderException as exc:
             logger.info(str(exc))
@@ -807,7 +806,7 @@ class Decider:
         try:
             value = get_fn(feature_name=feature_name, context=ctx)
         except FeatureNotFoundException as exc:
-            warnings.warn(str(exc))
+            logger.debug(str(exc))
             return default
         except ValueTypeMismatchException as exc:
             logger.info(str(exc))
@@ -844,7 +843,7 @@ class Decider:
         try:
             feature = self._internal.get_feature(experiment_name)
         except FeatureNotFoundException as exc:
-            warnings.warn(str(exc))
+            logger.debug(str(exc))
             return None
         except DeciderException as exc:
             logger.info(str(exc))

--- a/tests/decider_tests.py
+++ b/tests/decider_tests.py
@@ -565,7 +565,9 @@ class TestDeciderGetVariantAndExpose(unittest.TestCase):
             with self.assertLogs(logger, logging.DEBUG) as captured:
                 variant = decider.get_variant("anything")
 
-                assert any('Feature "anything" not found.' in x.getMessage() for x in captured.records)
+                assert any(
+                    'Feature "anything" not found.' in x.getMessage() for x in captured.records
+                )
             self.assertEqual(variant, None)
 
             # no exposures should be triggered
@@ -613,7 +615,9 @@ class TestDeciderGetVariantAndExpose(unittest.TestCase):
             with self.assertLogs(logger, logging.DEBUG) as captured:
                 variant = decider.get_variant_without_expose("anything")
 
-                assert any('Feature "anything" not found.' in x.getMessage() for x in captured.records)
+                assert any(
+                    'Feature "anything" not found.' in x.getMessage() for x in captured.records
+                )
             self.assertEqual(variant, None)
 
             # no exposures should be triggered

--- a/tests/decider_tests.py
+++ b/tests/decider_tests.py
@@ -562,13 +562,10 @@ class TestDeciderGetVariantAndExpose(unittest.TestCase):
             )
 
             self.assertEqual(self.event_logger.log.call_count, 0)
-            with warnings.catch_warnings(record=True) as captured:
+            with self.assertLogs(logger, logging.DEBUG) as captured:
                 variant = decider.get_variant("anything")
 
-                # can't test warning log only shows up only once if `decider.get_variant("anything")`
-                # is called again due to bug in `catch_warnings` contextmanager
-                # see https://github.com/python/cpython/issues/73858
-                assert any('Feature "anything" not found.' in str(x.message) for x in captured)
+                assert any('Feature "anything" not found.' in x.getMessage() for x in captured.records)
             self.assertEqual(variant, None)
 
             # no exposures should be triggered
@@ -613,13 +610,10 @@ class TestDeciderGetVariantAndExpose(unittest.TestCase):
             )
 
             self.assertEqual(self.event_logger.log.call_count, 0)
-            with warnings.catch_warnings(record=True) as captured:
+            with self.assertLogs(logger, logging.DEBUG) as captured:
                 variant = decider.get_variant_without_expose("anything")
 
-                # can't test warning log only shows up only once if `decider.get_variant("anything")`
-                # is called again due to bug in `catch_warnings` contextmanager
-                # see https://github.com/python/cpython/issues/73858
-                assert any('Feature "anything" not found.' in str(x.message) for x in captured)
+                assert any('Feature "anything" not found.' in x.getMessage() for x in captured.records)
             self.assertEqual(variant, None)
 
             # no exposures should be triggered


### PR DESCRIPTION
Moving the 'feature not found' logging to `debug` logger because the `warnings` 'log only once' approach is still spammy, especially after a fresh deployment when pods turn over & there's a burst of logs emitted. Those logs have to be suppressed via:
` warnings.filterwarnings("ignore", category=UserWarning, module="reddit_decider")`
so going to avoid it altogether.

If a service wants to know about bucketing calls for inactive features, they can enable `debug` logger, 
otherwise, a high traffic service can get really spammy if one of their experiments gets turned off and it starts emitting `warnings('feature not found')` logs.
