### PR TITLE
Drop FR manual exposures

### DIFF
--- a/reddit_decider/__init__.py
+++ b/reddit_decider/__init__.py
@@ -380,6 +380,10 @@ class Decider:
             logger.info(str(exc))
             return
 
+        # drop exposure for feature rollouts
+        if not feature.emit_event:
+            return
+
         event_context_fields = self._decider_context.to_event_dict()
         event_context_fields.update(exposure_kwargs or {})
         event_fields = deepcopy(event_context_fields)

--- a/tests/decider_tests.py
+++ b/tests/decider_tests.py
@@ -747,6 +747,19 @@ class TestDeciderGetVariantAndExpose(unittest.TestCase):
                 experiment_name="exp_1", variant=variant, event_fields=event_fields
             )
 
+    def test_feature_rollout_does_not_expose(self):
+        self.exp_base_config["exp_1"].update({"emit_event": False})
+
+        with create_temp_config_file(self.exp_base_config) as f:
+            decider = setup_decider(f, self.dc, self.mock_span, self.event_logger)
+
+            self.assertEqual(self.event_logger.log.call_count, 0)
+            variant = "variant_4"
+            decider.expose("exp_1", variant)
+
+            # exposure not fired
+            self.assertEqual(self.event_logger.log.call_count, 0)
+
     def test_expose_without_variant_name(self):
         with create_temp_config_file(self.exp_base_config) as f:
             decider = setup_decider(f.name, self.dc, self.mock_span, self.event_logger)


### PR DESCRIPTION
Drop exposure events for Feature Rollouts in calls to `expose()`