### PR TITLE
Bump min `reddit-v2-events` version in docs

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -14,7 +14,7 @@ Prerequisite packages
 
     reddit-edgecontext>=1.0.0
 
-    reddit-v2-events>=2.6.0
+    reddit-v2-events>=2.8.2
 
 Prerequisite infrastructure
 ---------------------------


### PR DESCRIPTION
Bump min package version necessary for `ExperimentLogger` to function (fixes `V2EventLogger` exception, internal to `ExperimentLogger`)