### PR TITLE
Add `subreddit_id`, `ad_account_id`, & `business_id` identifiers

### DIFF
--- a/reddit_decider/__init__.py
+++ b/reddit_decider/__init__.py
@@ -184,7 +184,7 @@ class Decider:
         event_logger: Optional[EventLogger] = None,
     ):
         self._decider_context = decider_context
-        self._internal = internal
+        self._internal: RustDecider = internal
         self._span = server_span
         self._context_name = context_name
         if event_logger:

--- a/reddit_decider/__init__.py
+++ b/reddit_decider/__init__.py
@@ -34,7 +34,7 @@ from typing_extensions import Literal
 logger = logging.getLogger(__name__)
 
 EMPLOYEE_ROLES = ["employee", "contractor"]
-IDENTIFIERS = ["user_id", "device_id", "canonical_url"]
+IDENTIFIERS = ["user_id", "device_id", "canonical_url", "subreddit_id", "ad_account_id"]
 TYPE_STR_LOOKUP = {bool: "boolean", int: "integer", float: "float", str: "string", dict: "map"}
 
 
@@ -177,7 +177,7 @@ class Decider:
         event_logger: Optional[EventLogger] = None,
     ):
         self._decider_context = decider_context
-        self._internal: RustDecider = internal
+        self._internal = internal
         self._span = server_span
         self._context_name = context_name
         if event_logger:
@@ -411,7 +411,7 @@ class Decider:
         self,
         experiment_name: str,
         identifier: str,
-        identifier_type: Literal["user_id", "device_id", "canonical_url"],
+        identifier_type: Literal["user_id", "device_id", "canonical_url", "subreddit_id", "ad_account_id"],
         **exposure_kwargs: Optional[Dict[str, Any]],
     ) -> Optional[str]:
         """Return a bucketing variant, if any, with auto-exposure for a given :code:`identifier`.
@@ -471,7 +471,7 @@ class Decider:
         self,
         experiment_name: str,
         identifier: str,
-        identifier_type: Literal["user_id", "device_id", "canonical_url"],
+        identifier_type: Literal["user_id", "device_id", "canonical_url", "subreddit_id", "ad_account_id"],
     ) -> Optional[str]:
         """Return a bucketing variant, if any, without emitting exposure event for a given :code:`identifier`.
 
@@ -587,7 +587,9 @@ class Decider:
         }
 
     def get_all_variants_for_identifier_without_expose(
-        self, identifier: str, identifier_type: Literal["user_id", "device_id", "canonical_url"]
+        self,
+        identifier: str,
+        identifier_type: Literal["user_id", "device_id", "canonical_url", "subreddit_id", "ad_account_id"]
     ) -> List[Dict[str, Union[str, int]]]:
         """Return a list of experiment dicts for experiments having :code:`bucket_val` match
         :code:`identifier_type`, for a given :code:`identifier`, in this format:

--- a/reddit_decider/__init__.py
+++ b/reddit_decider/__init__.py
@@ -419,7 +419,7 @@ class Decider:
         experiment_name: str,
         identifier: str,
         identifier_type: Literal[
-            "user_id", "device_id", "canonical_url", "subreddit_id", "ad_account_id"
+            "user_id", "device_id", "canonical_url", "subreddit_id", "ad_account_id", "business_id"
         ],
         **exposure_kwargs: Optional[Dict[str, Any]],
     ) -> Optional[str]:
@@ -481,7 +481,7 @@ class Decider:
         experiment_name: str,
         identifier: str,
         identifier_type: Literal[
-            "user_id", "device_id", "canonical_url", "subreddit_id", "ad_account_id"
+            "user_id", "device_id", "canonical_url", "subreddit_id", "ad_account_id", "business_id"
         ],
     ) -> Optional[str]:
         """Return a bucketing variant, if any, without emitting exposure event for a given :code:`identifier`.
@@ -601,7 +601,7 @@ class Decider:
         self,
         identifier: str,
         identifier_type: Literal[
-            "user_id", "device_id", "canonical_url", "subreddit_id", "ad_account_id"
+            "user_id", "device_id", "canonical_url", "subreddit_id", "ad_account_id", "business_id"
         ],
     ) -> List[Dict[str, Union[str, int]]]:
         """Return a list of experiment dicts for experiments having :code:`bucket_val` match

--- a/reddit_decider/__init__.py
+++ b/reddit_decider/__init__.py
@@ -34,7 +34,14 @@ from typing_extensions import Literal
 logger = logging.getLogger(__name__)
 
 EMPLOYEE_ROLES = ["employee", "contractor"]
-IDENTIFIERS = ["user_id", "device_id", "canonical_url", "subreddit_id", "ad_account_id", "business_id"]
+IDENTIFIERS = [
+    "user_id",
+    "device_id",
+    "canonical_url",
+    "subreddit_id",
+    "ad_account_id",
+    "business_id",
+]
 TYPE_STR_LOOKUP = {bool: "boolean", int: "integer", float: "float", str: "string", dict: "map"}
 
 
@@ -411,7 +418,9 @@ class Decider:
         self,
         experiment_name: str,
         identifier: str,
-        identifier_type: Literal["user_id", "device_id", "canonical_url", "subreddit_id", "ad_account_id"],
+        identifier_type: Literal[
+            "user_id", "device_id", "canonical_url", "subreddit_id", "ad_account_id"
+        ],
         **exposure_kwargs: Optional[Dict[str, Any]],
     ) -> Optional[str]:
         """Return a bucketing variant, if any, with auto-exposure for a given :code:`identifier`.
@@ -471,7 +480,9 @@ class Decider:
         self,
         experiment_name: str,
         identifier: str,
-        identifier_type: Literal["user_id", "device_id", "canonical_url", "subreddit_id", "ad_account_id"],
+        identifier_type: Literal[
+            "user_id", "device_id", "canonical_url", "subreddit_id", "ad_account_id"
+        ],
     ) -> Optional[str]:
         """Return a bucketing variant, if any, without emitting exposure event for a given :code:`identifier`.
 
@@ -589,7 +600,9 @@ class Decider:
     def get_all_variants_for_identifier_without_expose(
         self,
         identifier: str,
-        identifier_type: Literal["user_id", "device_id", "canonical_url", "subreddit_id", "ad_account_id"]
+        identifier_type: Literal[
+            "user_id", "device_id", "canonical_url", "subreddit_id", "ad_account_id"
+        ],
     ) -> List[Dict[str, Union[str, int]]]:
         """Return a list of experiment dicts for experiments having :code:`bucket_val` match
         :code:`identifier_type`, for a given :code:`identifier`, in this format:

--- a/reddit_decider/__init__.py
+++ b/reddit_decider/__init__.py
@@ -34,7 +34,7 @@ from typing_extensions import Literal
 logger = logging.getLogger(__name__)
 
 EMPLOYEE_ROLES = ["employee", "contractor"]
-IDENTIFIERS = ["user_id", "device_id", "canonical_url", "subreddit_id", "ad_account_id"]
+IDENTIFIERS = ["user_id", "device_id", "canonical_url", "subreddit_id", "ad_account_id", "business_id"]
 TYPE_STR_LOOKUP = {bool: "boolean", int: "integer", float: "float", str: "string", dict: "map"}
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 -r requirements-transitive.txt
 baseplate==2.0.0a1
 black==21.4b2
-reddit-decider==1.2.31
+reddit-decider==1.2.32
 flake8==3.9.1
 mypy==0.790
 pyramid==2.0   # required for `from baseplate.frameworks.pyramid import BaseplateRequest` which calls `import pyramid.events`

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     install_requires=[
         "baseplate>=2.0.0a1,<3.0",
         "reddit-edgecontext>=1.0.0a3,<2.0",
-        "reddit-decider~=1.2.31",
+        "reddit-decider~=1.2.32",
         "typing_extensions>=3.10.0.0,<5.0",
     ],
     package_data={"reddit_experiments": ["py.typed"], "reddit_decider": ["py.typed"]},

--- a/tests/decider_tests.py
+++ b/tests/decider_tests.py
@@ -968,7 +968,6 @@ class TestDeciderGetVariantAndExpose(unittest.TestCase):
             # no exposures should be triggered
             self.assertEqual(self.event_logger.log.call_count, 0)
 
-
     def test_get_variant_for_identifier_without_expose_business_id(self):
         identifier = BUSINESS_ID
         bucket_val = "business_id"


### PR DESCRIPTION
### Summary
This pr adds three new identifiers to the allow-list utilized by `get_variant_for_identifier*()` API:
- `subreddit_id`
- `ad_account_id`
- `business_id`
