### PR TITLE
Bump `twine` package due to failure in github Actions

### DIFF
--- a/.github/workflows/python-publish.yaml
+++ b/.github/workflows/python-publish.yaml
@@ -20,7 +20,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install setuptools==47.3.0 wheel==0.34.2 twine==3.1.1
+        python -m pip install setuptools==47.3.0 wheel==0.34.2 twine==3.2.0
 
     - name: Build and publish
       env:


### PR DESCRIPTION
`twine` package (used to upload this package to pypi) is [erroring in github Actions](https://github.com/reddit/experiments.py/actions/runs/4951912636/jobs/8857593796).

Not really sure what to do except bump it to the [next available version](https://github.com/pypa/twine/tags?after=3.5.0).