### PR TITLE
fix urllib3 version in Actions workflow

### DIFF
--- a/.github/workflows/python-publish.yaml
+++ b/.github/workflows/python-publish.yaml
@@ -20,7 +20,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install setuptools==47.3.0 wheel==0.34.2 twine==3.2.0
+        python -m pip install setuptools==47.3.0 wheel==0.34.2 urllib3==1.26.15 twine==3.1.1
 
     - name: Build and publish
       env:


### PR DESCRIPTION
Upgrading `twine` [didn't help](https://github.com/reddit/experiments.py/actions/runs/4952772434/jobs/8859503873) fix the issue in Actions CI, but I found the root of the issue:
https://learn.microsoft.com/en-us/answers/questions/1276637/arcgis-package-urllib3-library-issue

pinning `urllib3` to last known version before 2.x upgrade should work.
Also, reverted `twine` version bump.