### PR TITLE
Expose `self._internal` Decider

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,12 +10,13 @@ Documentation: https://reddit-experiments.readthedocs.io/
 Install the library:
 
 ```console
-$ pip install reddit-experiments
+$ pip install reddit-experiments reddit-v2-events>=2.8.2
 ```
 
 Add the client to your application's Baseplate context:
 
 ```python
+ from event_utils.v2_event_utils import ExperimentLogger
  from reddit_decider import decider_client_from_config
 
  decider = decider_client_from_config(

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Documentation: https://reddit-experiments.readthedocs.io/
 Install the library:
 
 ```console
+# `reddit-v2-events` is a Reddit internal package used for emitting exposure events
 $ pip install reddit-experiments reddit-v2-events>=2.8.2
 ```
 

--- a/reddit_decider/__init__.py
+++ b/reddit_decider/__init__.py
@@ -192,6 +192,9 @@ class Decider:
         else:
             self._event_logger = DebugLogger()
 
+    def internal_decider(self) -> RustDecider:
+        return self._internal
+
     def _send_expose(self, event: str, exposure_fields: dict) -> None:
         event_fields = deepcopy(exposure_fields)
         try:


### PR DESCRIPTION
add support for grabbing internal Decider instance off of top-level Decider, instead of accessing the `_internal` instance variable directly.