### PR TITLE
fix `T` TypeVar

### DIFF
--- a/reddit_decider/__init__.py
+++ b/reddit_decider/__init__.py
@@ -67,10 +67,6 @@ class DeciderContext:
 
     :param user_id: user's t2 id
     :param device_id: device installation uuid
-    :param canonical_url: an url string
-    :param subreddit_id: subreddit link's t3 identifier
-    :param ad_account_id: an ad_account id string identifier
-    :param business_id: business id identifier used by ads
     :param country_code: 2-letter country codes
     :param locale: ISO 639-1 primary language subtag and an optional ISO 3166-1 alpha-2 region subtag
     :param user_is_employee:
@@ -86,9 +82,6 @@ class DeciderContext:
         self,
         user_id: Optional[str] = None,
         device_id: Optional[str] = None,
-        subreddit_id: Optional[str] = None,
-        ad_account_id: Optional[str] = None,
-        business_id: Optional[str] = None,
         country_code: Optional[str] = None,
         locale: Optional[str] = None,
         user_is_employee: Optional[bool] = None,
@@ -101,9 +94,6 @@ class DeciderContext:
     ):
         self._user_id = user_id
         self._device_id = device_id
-        self._subreddit_id = subreddit_id
-        self._ad_account_id = ad_account_id
-        self._business_id = business_id
         self._country_code = country_code
         self._locale = locale
         self._user_is_employee = user_is_employee
@@ -120,9 +110,6 @@ class DeciderContext:
         return {
             "user_id": self._user_id,
             "device_id": self._device_id,
-            "subreddit_id": self._subreddit_id,
-            "ad_account_id": self._ad_account_id,
-            "business_id": self._business_id,
             "country_code": self._country_code,
             "locale": self._locale,
             "user_is_employee": self._user_is_employee,
@@ -167,10 +154,6 @@ class DeciderContext:
         if self._device_id:
             platform_fields["device_id"] = self._device_id
 
-        subreddit_fields = {}
-        if self._subreddit_id:
-            subreddit_fields["id"] = self._subreddit_id
-
         return {
             "user_id": self._user_id,
             "country_code": self._country_code,
@@ -185,7 +168,6 @@ class DeciderContext:
             "geo": geo_fields,
             "request": request_fields,
             "platform": platform_fields,
-            "subreddit": subreddit_fields,
             **ef,
         }
 

--- a/tests/decider_tests.py
+++ b/tests/decider_tests.py
@@ -739,7 +739,11 @@ class TestDeciderGetVariantAndExpose(unittest.TestCase):
             self.assertEqual(self.event_logger.log.call_count, 1)
             event_fields = self.event_logger.log.call_args[1]
             self.assert_exposure_event_fields(
-                experiment_name="exp_1", variant=variant, event_fields=event_fields, bucket_val=bucket_val, identifier=identifier
+                experiment_name="exp_1",
+                variant=variant,
+                event_fields=event_fields,
+                bucket_val=bucket_val,
+                identifier=identifier,
             )
 
     def test_get_variant_for_identifier_ad_account_id(self):

--- a/tests/decider_tests.py
+++ b/tests/decider_tests.py
@@ -735,6 +735,13 @@ class TestDeciderGetVariantAndExpose(unittest.TestCase):
             # `identifier` passed to correct event field of experiment's `bucket_val` config
             self.assertEqual(event_fields["subreddit_id"], identifier)
 
+            # exposure assertions
+            self.assertEqual(self.event_logger.log.call_count, 1)
+            event_fields = self.event_logger.log.call_args[1]
+            self.assert_exposure_event_fields(
+                experiment_name="exp_1", variant=variant, event_fields=event_fields, bucket_val=bucket_val, identifier=identifier
+            )
+
     def test_get_variant_for_identifier_ad_account_id(self):
         identifier = AD_ACCOUNT_ID
         bucket_val = "ad_account_id"

--- a/tests/decider_tests.py
+++ b/tests/decider_tests.py
@@ -3,14 +3,12 @@ import json
 import logging
 import tempfile
 import unittest
-import warnings
 
 from unittest import mock
 
 from baseplate import RequestContext
 from baseplate import ServerSpan
 from baseplate.lib.events import DebugLogger
-from baseplate.lib.file_watcher import FileWatcher
 from reddit_edgecontext import ValidatedAuthenticationToken
 
 from reddit_decider import Decider
@@ -1409,7 +1407,7 @@ class TestDeciderGetVariantAndExpose(unittest.TestCase):
 
             with self.assertLogs() as captured:
                 variant_arr = decider.get_all_variants_for_identifier_without_expose(
-                    identifier=identifier, identifier_type="blah"
+                    identifier=identifier, identifier_type=identifier_type
                 )
 
                 self.assertEqual(len(variant_arr), 0)
@@ -1497,7 +1495,7 @@ class TestDeciderGetVariantAndExpose(unittest.TestCase):
             self.assertEqual(self.event_logger.log.call_count, 0)
             variant = decider.get_variant_without_expose("exp_1")
 
-            assert variant == None
+            assert variant is None
 
             # exposure from control_1 of "hg"
             self.assertEqual(self.event_logger.log.call_count, 1)


### PR DESCRIPTION
#Summary
- fix bug where we use `from baseplate.lib.file_watcher import T` to define a generic type, instead of defining it in the file