### PR TITLE
Bump Decider (re-enable `PartialLoad` error), update version in docs + tests

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -62,7 +62,7 @@ Upgrade or integrate reddit-experiments package:
 .. code-block:: python
 
     # import latest reddit-experiments package in service requirements.txt
-    reddit-experiments>=1.6.0
+    reddit-experiments>=1.7.0
 
 Initialize :code:`decider` instance on Baseplate context
 --------------------------------------------------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -62,7 +62,7 @@ Upgrade or integrate reddit-experiments package:
 .. code-block:: python
 
     # import latest reddit-experiments package in service requirements.txt
-    reddit-experiments>=1.4.0
+    reddit-experiments>=1.6.0
 
 Initialize :code:`decider` instance on Baseplate context
 --------------------------------------------------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -43,7 +43,9 @@ Setup :code:`reddit-experiments` in your application's configuration file:
    experiments.path = /var/local/foo.json
 
    # optional: how long to wait for the experiments file to exist before failing
-   # (default: do not wait. fail immediately if not available)
+   # default:
+   #    >= v1.7.0 wait 30 seconds
+   #    <  v1.7.0 do not wait, fail immediately if not available
    experiments.timeout = 60 seconds
 
    # optional: the base amount of time for exponential backoff while waiting

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,7 +4,7 @@ docutils==0.16
 Jinja2==2.11.2
 MarkupSafe==1.1.1
 pydocstyle==5.1.1
-reddit-decider==1.4.0
+reddit-decider==1.4.1
 reddit-edgecontext==1.0.0a3
 Sphinx==3.4.0
 sphinx-autodoc-typehints==1.11.1

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,7 +4,7 @@ docutils==0.16
 Jinja2==2.11.2
 MarkupSafe==1.1.1
 pydocstyle==5.1.1
-reddit-decider==1.3.1
+reddit-decider==1.4.0
 reddit-edgecontext==1.0.0a3
 Sphinx==3.4.0
 sphinx-autodoc-typehints==1.11.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 -r requirements-transitive.txt
 baseplate>=2.0.0a1,<3.0
 black==21.4b2
-reddit-decider==1.3.1
+reddit-decider==1.4.0
 flake8==3.9.1
 mypy==0.790
 pyramid==2.0   # required for `from baseplate.frameworks.pyramid import BaseplateRequest` which calls `import pyramid.events`

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 -r requirements-transitive.txt
 baseplate>=2.0.0a1,<3.0
 black==21.4b2
-reddit-decider==1.4.0
+reddit-decider==1.4.1
 flake8==3.9.1
 mypy==0.790
 pyramid==2.0   # required for `from baseplate.frameworks.pyramid import BaseplateRequest` which calls `import pyramid.events`

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     install_requires=[
         "baseplate>=2.0.0a1,<3.0",
         "reddit-edgecontext>=1.0.0a3,<2.0",
-        "reddit-decider~=1.4.0",
+        "reddit-decider~=1.4.1",
         "typing_extensions>=3.10.0.0,<5.0",
     ],
     package_data={"reddit_experiments": ["py.typed"], "reddit_decider": ["py.typed"]},

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     install_requires=[
         "baseplate>=2.0.0a1,<3.0",
         "reddit-edgecontext>=1.0.0a3,<2.0",
-        "reddit-decider~=1.3.1",
+        "reddit-decider~=1.4.0",
         "typing_extensions>=3.10.0.0,<5.0",
     ],
     package_data={"reddit_experiments": ["py.typed"], "reddit_decider": ["py.typed"]},

--- a/tests/decider_tests.py
+++ b/tests/decider_tests.py
@@ -1488,7 +1488,13 @@ class TestDeciderGetVariantAndExpose(unittest.TestCase):
 
         self.exp_base_config["exp_1"]["experiment"].update({"overrides": [group_overrides]})
         # reset variant for override to make sure it's not organically bucketed into it
-        self.exp_base_config["exp_1"]["experiment"].update({"variants": [{"range_start": 0.0, "range_end": 0.0, "name": "variant_2"},]})
+        self.exp_base_config["exp_1"]["experiment"].update(
+            {
+                "variants": [
+                    {"range_start": 0.0, "range_end": 0.0, "name": "variant_2"},
+                ]
+            }
+        )
 
         og_cfg = {
             "$override_groups": {
@@ -1506,9 +1512,7 @@ class TestDeciderGetVariantAndExpose(unittest.TestCase):
                 "owner": "test",
                 "name": "$override_group",
                 "value_type": "Map",
-                "experiment": {
-                    "experiment_version": 1
-                }
+                "experiment": {"experiment_version": 1},
             },
         }
         self.exp_base_config.update(og_cfg)

--- a/tests/decider_tests.py
+++ b/tests/decider_tests.py
@@ -1534,9 +1534,6 @@ class TestDeciderGetVariantAndExpose(unittest.TestCase):
             # no exposures should be triggered
             self.assertEqual(self.event_logger.log.call_count, 0)
 
-    def test_get_variant_for_okta_groups_non_user_id_identifier(self):
-        pass
-
 
 class TestDeciderGetDynamicConfig(unittest.TestCase):
     def setUp(self):

--- a/tests/decider_tests.py
+++ b/tests/decider_tests.py
@@ -1642,7 +1642,6 @@ class TestDeciderGetDynamicConfig(unittest.TestCase):
             res = decider.get_map("dc_1")
             self.assertEqual(res, None)
 
-
     def test_get_all_values(self):
         base_cfg = self.dc_base_config["dc_1"].copy()
 

--- a/tests/decider_tests.py
+++ b/tests/decider_tests.py
@@ -1630,6 +1630,19 @@ class TestDeciderGetDynamicConfig(unittest.TestCase):
             res = decider.get_string("dc_1")
             self.assertEqual(res, "")
 
+    def test_get_map_disabled(self):
+        self.dc_base_config["dc_1"].update(
+            {"value_type": "Map", "value": {"key": "value", "another_key": "another_value"}}
+        )
+        self.dc_base_config["dc_1"].update({"enabled": False})
+
+        with create_temp_config_file(self.dc_base_config) as f:
+            decider = setup_decider(f, self.dc, self.mock_span, self.event_logger)
+
+            res = decider.get_map("dc_1")
+            self.assertEqual(res, None)
+
+
     def test_get_all_values(self):
         base_cfg = self.dc_base_config["dc_1"].copy()
 

--- a/tests/experiment_tests.py
+++ b/tests/experiment_tests.py
@@ -710,6 +710,7 @@ class TestExperiments(unittest.TestCase):
 
         self.assertEqual(variant, "active")
 
+
 @mock.patch("reddit_experiments.FileWatcher")
 class ExperimentsClientFromConfigTests(unittest.TestCase):
     def test_make_clients(self, file_watcher_mock):


### PR DESCRIPTION
- bump `reddit-decider` to bring back catching `PartialLoad` error
- update docs on `experiments.timeout` config
- add okta_group lookup test
- add arbitrary identifier v1 SDK compatibility test
