### PR TITLE
Re-raise exceptions from `request_field_extractor` + prom metrics

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -39,8 +39,9 @@ Setup :code:`reddit-experiments` in your application's configuration file:
    ...
 
    # optional: a path to the file where experiment configuration is written
-   # (default: /var/local/experiments.json)
-   experiments.path = /var/local/foo.json
+   # default: /var/local/experiments.json
+   # note: production systems load the experiments.json file under nested `live-data/` dir
+   experiments.path = /var/local/live-data/experiments.json
 
    # optional: how long to wait for the experiments file to exist before failing
    # default:
@@ -50,7 +51,7 @@ Setup :code:`reddit-experiments` in your application's configuration file:
 
    # optional: the base amount of time for exponential backoff while waiting
    # for the file to be available.
-   # (default: no backoff time between tries)
+   # default: no backoff time between tries
    experiments.backoff = 1 second
 
    ...

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,8 @@
 [tool.black]
 line-length = 100
 target-version = ['py36']
+
+[project]
+dynamic = ["version"]
+
+[tool.setuptools_scm]

--- a/reddit_decider/__init__.py
+++ b/reddit_decider/__init__.py
@@ -4,9 +4,10 @@ from copy import deepcopy
 from dataclasses import dataclass
 from datetime import timedelta
 from enum import Enum
-from sys import version_info as py_version
+import sys
 from typing import Any
 from typing import Callable
+from typing import cast
 from typing import Dict
 from typing import IO
 from typing import List
@@ -34,13 +35,15 @@ from typing_extensions import Literal
 from .prometheus_metrics import experiments_client_counter
 
 # get package's version for prometheus metrics
-if py_version >= (3, 8):
-    from importlib.metadata import version as pkg_version, PackageNotFoundError  # type: ignore
+if sys.version_info >= (3, 8):
+    from importlib.metadata import version as pkg_version, PackageNotFoundError
 else:
     from importlib_metadata import version as pkg_version, PackageNotFoundError
 
 try:
-    _pkg_version = pkg_version("reddit-experiments")
+    # see https://github.com/python/mypy/issues/8823#issuecomment-1484368501
+    # for why cast is used (mypy)
+    _pkg_version = cast(Callable[[str], str], pkg_version)("reddit-experiments")
 except PackageNotFoundError:
     _pkg_version = ""
 

--- a/reddit_decider/__init__.py
+++ b/reddit_decider/__init__.py
@@ -35,9 +35,9 @@ from .prometheus_metrics import experiments_client_counter
 
 # get package's version for metrics
 if py_version >= (3, 8):
-    from importlib.metadata import version as pkg_version, PackageNotFoundError
+    from importlib.metadata import version as pkg_version
 else:
-    from importlib_metadata import version as pkg_version, PackageNotFoundError
+    from importlib_metadata import version as pkg_version
 
 _pkg_version = pkg_version("reddit-experiments")
 

--- a/reddit_decider/__init__.py
+++ b/reddit_decider/__init__.py
@@ -1006,7 +1006,7 @@ class DeciderContextFactory(ContextFactory):
         )
 
     def make_object_for_context(self, name: str, span: Span) -> Decider:
-        def inc_failure_counter(failure_type: str):
+        def inc_failure_counter(failure_type: str) -> None:
             experiments_client_counter.labels(
                 operation="make_object_for_context",
                 success="false",

--- a/reddit_decider/__init__.py
+++ b/reddit_decider/__init__.py
@@ -1024,7 +1024,7 @@ class DeciderContextFactory(ContextFactory):
 
         # check for `span`'s presence
         if span is None:
-            inc_failure_counter("missing_span")
+            inc_failure_counter("missing:'span'")
             logger.debug("`span` is `None` in reddit_decider `make_object_for_context()`.")
             return self._minimal_decider(internal=rs_decider, name=name, span=span)
 
@@ -1032,7 +1032,7 @@ class DeciderContextFactory(ContextFactory):
         request = getattr(span, "context", None)
 
         if request is None:
-            inc_failure_counter("missing_span_context")
+            inc_failure_counter("missing:'span.context'")
             return self._minimal_decider(
                 internal=rs_decider,
                 name=name,
@@ -1060,6 +1060,7 @@ class DeciderContextFactory(ContextFactory):
         ec = getattr(request, "edge_context", None)
         # if `edge_context` is inaccessible, bail field extraction early
         if ec is None:
+            inc_failure_counter("missing:'request.edge_context'")
             return self._minimal_decider(
                 internal=rs_decider,
                 name=name,

--- a/reddit_decider/__init__.py
+++ b/reddit_decider/__init__.py
@@ -1,10 +1,10 @@
 import logging
+import sys
 
 from copy import deepcopy
 from dataclasses import dataclass
 from datetime import timedelta
 from enum import Enum
-import sys
 from typing import Any
 from typing import Callable
 from typing import cast

--- a/reddit_decider/__init__.py
+++ b/reddit_decider/__init__.py
@@ -33,13 +33,16 @@ from typing_extensions import Literal
 
 from .prometheus_metrics import experiments_client_counter
 
-# get package's version for metrics
+# get package's version for prometheus metrics
 if py_version >= (3, 8):
-    from importlib.metadata import version as pkg_version
+    from importlib.metadata import version as pkg_version, PackageNotFoundError  # type: ignore
 else:
-    from importlib_metadata import version as pkg_version
+    from importlib_metadata import version as pkg_version, PackageNotFoundError
 
-_pkg_version = pkg_version("reddit-experiments")
+try:
+    _pkg_version = pkg_version("reddit-experiments")
+except PackageNotFoundError:
+    _pkg_version = ""
 
 logger = logging.getLogger(__name__)
 

--- a/reddit_decider/prometheus_metrics.py
+++ b/reddit_decider/prometheus_metrics.py
@@ -1,0 +1,7 @@
+from prometheus_client import Counter
+
+experiments_client_counter = Counter(
+    "experiments_py_client_total",
+    "Count of successful/failed Experiments.py operations (with error_type) in reddit-experiments package",
+    ["operation", "success", "error_type", "pkg_version"],
+)

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ black==21.4b2
 reddit-decider==1.4.1
 flake8==3.9.1
 mypy==0.790
+prometheus-client>=0.12.0,<1.0
 pyramid==2.0   # required for `from baseplate.frameworks.pyramid import BaseplateRequest` which calls `import pyramid.events`
 pydocstyle==5.1.1
 pytest==6.2.5

--- a/tests/decider_tests.py
+++ b/tests/decider_tests.py
@@ -86,7 +86,6 @@ class DeciderClientFromConfigTests(unittest.TestCase):
         super().setUp()
         self.event_logger = mock.Mock(spec=DebugLogger)
         self.mock_span = mock.MagicMock(spec=ServerSpan)
-        self.mock_span.context = None
 
     def test_make_client_without_timeout_set(self, file_watcher_mock):
         with create_temp_config_file({}) as f:
@@ -219,7 +218,8 @@ class DeciderContextFactoryTests(unittest.TestCase):
         self.assertEqual(decider_event_dict["canonical_url"], CANONICAL_URL)
         self.assertEqual(decider_event_dict["request"]["canonical_url"], CANONICAL_URL)
 
-    def test_make_object_for_context_and_decider_context_without_span(self):
+    @mock.patch("reddit_decider.experiments_client_counter.labels")
+    def test_make_object_for_context_without_span(self, metric_counter_labels):
         with create_temp_config_file({}) as f:
             decider_ctx_factory = decider_client_from_config(
                 {"experiments.path": f.name, "experiments.timeout": "2 seconds"},
@@ -236,13 +236,56 @@ class DeciderContextFactoryTests(unittest.TestCase):
             assert len(captured.records) == 1
             self.assertEqual(["WARNING:root:Dummy warning"], captured.output)
 
+            metric_counter_labels.assert_called_once_with(
+                operation="make_object_for_context",
+                success="false",
+                error_type="missing_span",
+                pkg_version=mock.ANY,
+            )
+
         self.assertIsInstance(decider, Decider)
 
         decider_ctx_dict = decider._decider_context.to_dict()
         self.assertEqual(decider_ctx_dict["user_id"], None)
 
-    def test_make_object_for_context_and_decider_context_with_broken_decider_field_extractor(self):
-        def broken_decider_field_extractor(_request: RequestContext):
+    @mock.patch("reddit_decider.experiments_client_counter.labels")
+    def test_make_object_for_context_with_span_context_as_None(self, metric_counter_labels):
+        with create_temp_config_file({}) as f:
+            decider_ctx_factory = decider_client_from_config(
+                {"experiments.path": f.name, "experiments.timeout": "2 seconds"},
+                self.event_logger,
+                prefix="experiments.",
+                request_field_extractor=decider_field_extractor,
+            )
+
+        mock_span = mock.MagicMock(spec=ServerSpan)
+        # span is missing context
+
+        with self.assertLogs(logger, logging.WARN) as captured:
+            # ensure no warnings are printed except for the dummy one
+            # https://stackoverflow.com/a/61381576/4260179
+            logger.warning("Dummy warning")
+
+            decider = decider_ctx_factory.make_object_for_context(name="test", span=mock_span)
+            assert len(captured.records) == 1
+            self.assertEqual(["WARNING:root:Dummy warning"], captured.output)
+
+            metric_counter_labels.assert_called_once_with(
+                operation="make_object_for_context",
+                success="false",
+                error_type="missing_span_context",
+                pkg_version=mock.ANY,
+            )
+
+        self.assertIsInstance(decider, Decider)
+
+        decider_ctx_dict = decider._decider_context.to_dict()
+        self.assertEqual(decider_ctx_dict["user_id"], None)
+
+    def test_make_object_for_context_and_decider_context_with_malformed_decider_field_extractor(
+        self,
+    ):
+        def decider_field_extractor_with_malformed_fields(_request: RequestContext):
             return {
                 "app_name": {},
                 "build_number": BUILD_NUMBER,
@@ -256,7 +299,7 @@ class DeciderContextFactoryTests(unittest.TestCase):
                 {"experiments.path": f.name, "experiments.timeout": "2 seconds"},
                 self.event_logger,
                 prefix="experiments.",
-                request_field_extractor=broken_decider_field_extractor,
+                request_field_extractor=decider_field_extractor_with_malformed_fields,
             )
 
         with self.assertLogs() as captured:
@@ -279,6 +322,39 @@ class DeciderContextFactoryTests(unittest.TestCase):
                 in x.getMessage()
                 for x in captured.records
             )
+
+    @mock.patch("reddit_decider.experiments_client_counter.labels")
+    def test_make_object_for_context_with_broken_decider_field_extractor_raises_exception(
+        self, metric_counter_labels
+    ):
+        class SomeException(Exception):
+            pass
+
+        def broken_decider_field_extractor(_request: RequestContext):
+            raise SomeException("bad extractor")
+
+        with create_temp_config_file({}) as f:
+            decider_ctx_factory = decider_client_from_config(
+                {"experiments.path": f.name, "experiments.timeout": "2 seconds"},
+                self.event_logger,
+                prefix="experiments.",
+                request_field_extractor=broken_decider_field_extractor,
+            )
+
+        with self.assertRaises(SomeException) as e:
+            decider_ctx_factory.make_object_for_context(name="test", span=self.mock_span)
+
+        self.assertEqual(
+            str(e.exception),
+            "bad extractor",
+        )
+
+        metric_counter_labels.assert_called_once_with(
+            operation="make_object_for_context",
+            success="false",
+            error_type="request_field_extractor",
+            pkg_version=mock.ANY,
+        )
 
 
 # Todo: test DeciderClient()

--- a/tests/decider_tests.py
+++ b/tests/decider_tests.py
@@ -239,7 +239,7 @@ class DeciderContextFactoryTests(unittest.TestCase):
             metric_counter_labels.assert_called_once_with(
                 operation="make_object_for_context",
                 success="false",
-                error_type="missing_span",
+                error_type="missing:'span'",
                 pkg_version=mock.ANY,
             )
 
@@ -273,7 +273,7 @@ class DeciderContextFactoryTests(unittest.TestCase):
             metric_counter_labels.assert_called_once_with(
                 operation="make_object_for_context",
                 success="false",
-                error_type="missing_span_context",
+                error_type="missing:'span_context'",
                 pkg_version=mock.ANY,
             )
 

--- a/tests/decider_tests.py
+++ b/tests/decider_tests.py
@@ -273,7 +273,7 @@ class DeciderContextFactoryTests(unittest.TestCase):
             metric_counter_labels.assert_called_once_with(
                 operation="make_object_for_context",
                 success="false",
-                error_type="missing:'span_context'",
+                error_type="missing:'span.context'",
                 pkg_version=mock.ANY,
             )
 


### PR DESCRIPTION
Exceptions raised by calling user-defined  `request_field_extractor` function were previously swallowed and there was no visibility into the failure except for a log line.

This pr:
- re-raises exceptions from user-defined `request_field_extractor` (also makes debugging incorrect extractors easier during integration)
- adds prometheus metrics in `make_object_for_context()` for better visibility of failure modes
  - the version of the package being run in a deployment is determined via `importlib.metadata` for py >= 3.8 and via `importlib_metadata` for py 3.7
- removes some `try`/`except`  blocks in favor of using `getattr()`/`return if None` approach
