### PR TITLE
Bump `reddit-decider` to enable expose functionality on low-level decider

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,7 +4,7 @@ docutils==0.16
 Jinja2==2.11.2
 MarkupSafe==1.1.1
 pydocstyle==5.1.1
-reddit-decider==1.4.1
+reddit-decider==1.7.0
 reddit-edgecontext==1.0.0a3
 Sphinx==3.4.0
 sphinx-autodoc-typehints==1.11.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 -r requirements-transitive.txt
 baseplate>=2.0.0a1,<3.0
 black==21.4b2
-reddit-decider==1.4.1
+reddit-decider==1.7.0
 flake8==3.9.1
 mypy==0.790
 prometheus-client>=0.12.0,<1.0

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     install_requires=[
         "baseplate>=2.0.0a1,<3.0",
         "reddit-edgecontext>=1.0.0a3,<2.0",
-        "reddit-decider~=1.4.1",
+        "reddit-decider~=1.7.0",
         "typing_extensions>=3.10.0.0,<5.0",
     ],
     package_data={"reddit_experiments": ["py.typed"], "reddit_decider": ["py.typed"]},


### PR DESCRIPTION
e.g. `rust_decider` module is accessible via this `reddit-experiments` package:
```
from rust_decider import Decider
from rust_decider import Exposer

from baseplate.lib.events import EventQueue

serializer = lambda s: s.encode("utf-8")
eq = EventQueue(name="v2", event_serializer=serializer)
exposer = Exposer(expose_fn=eq.put)

decider = Decider("experiments.json", exposer)

# choose w/ expose
choice = decider_exposer.choose(
        feature_name="exp_name", 
        context={
           "user_id": "t2_abc",
           "user_is_employee": True,
           "other_info": { "arbitrary_field": "some_val" }
        },
       expose=True
)

# verify events were present to be emitted
len(choice.full_events)
dict(choice.full_events[0])
```

If only holdouts are intended to be exposed, this can be accomplished by:
```
choice = decider_exposer.choose(
        feature_name="exp_name", 
        context={
           ...
        },
       expose=False,
       expose_holdout=True
)
```