### PR TITLE
Support reddit-decider 1.18 on Python 3.9+

### DIFF
--- a/.github/workflows/python-package.yaml
+++ b/.github/workflows/python-package.yaml
@@ -13,7 +13,17 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.8', '3.9', '3.10']
+        include:
+        - python-version: '3.8'
+          reddit-decider-version: '1.15.0'
+        - python-version: '3.9'
+          reddit-decider-version: '1.15.0'
+        - python-version: '3.9'
+          reddit-decider-version: '1.18.1'
+        - python-version: '3.10'
+          reddit-decider-version: '1.15.0'
+        - python-version: '3.10'
+          reddit-decider-version: '1.18.1'
 
     steps:
     - uses: actions/checkout@v2
@@ -33,6 +43,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install -r requirements.txt
+        python -m pip install "reddit-decider==${{ matrix.reddit-decider-version }}"
 
     - name: Lint
       run: |

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,7 +4,8 @@ docutils==0.16
 Jinja2==2.11.2
 MarkupSafe==1.1.1
 pydocstyle==5.1.1
-reddit-decider==1.15.0
+reddit-decider==1.15.0; python_version < "3.9"
+reddit-decider==1.18.1; python_version >= "3.9"
 reddit-edgecontext==1.0.0a3
 Sphinx==3.4.0
 sphinx-autodoc-typehints==1.11.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,8 @@
 -r requirements-transitive.txt
 baseplate>=2.0.0a1,<3.0
 black==21.4b2
-reddit-decider==1.15.0
+reddit-decider==1.15.0; python_version < "3.9"
+reddit-decider==1.18.1; python_version >= "3.9"
 flake8==3.9.1
 mypy==0.790
 prometheus-client>=0.12.0,<1.0

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,8 @@ setup(
     install_requires=[
         "baseplate>=2.0.0a1,<3.0",
         "reddit-edgecontext>=1.0.0a3,<2.0",
-        "reddit-decider~=1.15.0",
+        "reddit-decider>=1.15.0,<1.16.0; python_version < '3.9'",
+        "reddit-decider>=1.15.0,<1.19.0; python_version >= '3.9'",
         "typing_extensions>=3.10.0.0,<5.0",
     ],
     package_data={"reddit_experiments": ["py.typed"], "reddit_decider": ["py.typed"]},

--- a/tests/decider_tests.py
+++ b/tests/decider_tests.py
@@ -4,11 +4,13 @@ import logging
 import tempfile
 import unittest
 
+from importlib.metadata import version as package_version
 from unittest import mock
 
 from baseplate import RequestContext
 from baseplate import ServerSpan
 from baseplate.lib.events import DebugLogger
+from packaging.version import Version
 from reddit_edgecontext import ValidatedAuthenticationToken
 
 from reddit_decider import Decider
@@ -19,6 +21,8 @@ from reddit_decider import EventType
 from reddit_decider import init_decider_parser
 
 logger = logging.getLogger()
+
+DECIDER_SUPPORTS_PROPERTY_REGISTRY = Version(package_version("reddit-decider")) >= Version("1.18.1")
 
 USER_ID = "t2_1234"
 IS_LOGGED_IN = True
@@ -538,6 +542,27 @@ class TestDeciderGetVariantAndExpose(unittest.TestCase):
             self.assert_exposure_event_fields(
                 experiment_name="exp_1", variant=variant, event_fields=event_fields
             )
+
+    @unittest.skipUnless(
+        DECIDER_SUPPORTS_PROPERTY_REGISTRY,
+        "property registries require reddit-decider 1.18.1 or newer",
+    )
+    def test_manifest_with_property_registry_preserves_experiments(self):
+        config = dict(self.exp_base_config)
+        config["$properties"] = {
+            "ranking_algorithm": {
+                "type": "String",
+                "fallback_value": "hot_v1",
+                "targeted_values": [],
+            }
+        }
+
+        with create_temp_config_file(config) as f:
+            decider = setup_decider(f, self.dc, self.mock_span, self.event_logger)
+
+            variant = decider.get_variant_without_expose(experiment_name="exp_1")
+
+        self.assertEqual(variant, "variant_4")
 
     def test_none_returned_on_get_variant_call_with_bad_id(self):
         config = {


### PR DESCRIPTION
## Summary

- support `reddit-decider` 1.18.x on Python 3.9 and newer
- retain the existing Decider 1.15.x range on Python 3.8
- test both Decider 1.15.0 and 1.18.1 in CI
- verify that a manifest containing `$properties` preserves ordinary experiment evaluation

Python 3.8 remains on Decider 1.15.x because the newer Decider dependency stack requires Python 3.9 or newer.

## Rollout

The first package publication will be `1.11.0rc1` so consumers must opt in. A stable `1.11.0` release will follow only after the prerelease has been exercised by the pilot service.

## Verification

- Decider 1.15.0: 203 passed, 19 skipped
- Decider 1.18.1: 204 passed, 18 skipped
- Python 3.8 release-toolchain wheel and sdist build
- `twine check` for both distributions
- wheel metadata verified for both conditional Decider ranges

---
Built with [Snoocode](https://pages.github.snooguts.net/reddit/snoocode-app/open/pr/?owner=reddit&repo=experiments.py&number=123&branch=snoocode/decider-1.18-compatibility)